### PR TITLE
Posenet - scale factor

### DIFF
--- a/posenet/README.md
+++ b/posenet/README.md
@@ -57,7 +57,7 @@ All keypoints are indexed by part id.  The parts and their ids are:
 Single pose estimation is the simpler and faster of the two algorithms. Its ideal use case is for when there is only one person in the image. The disadvantage is that if there are multiple persons in an image, keypoints from both persons will likely be estimated as being part of the same single pose—meaning, for example, that person #1’s left arm and person #2’s right knee might be conflated by the algorithm as belonging to the same pose.
 
 ```javascript
-const pose = await poseNet.estimateSinglePose(image, imageScaleFactor, reverse, outputStride);
+const pose = await poseNet.estimateSinglePose(image, imageScaleFactor, flipHorizontal, outputStride);
 ```
 
 #### Inputs
@@ -65,7 +65,7 @@ const pose = await poseNet.estimateSinglePose(image, imageScaleFactor, reverse, 
 * **image** - ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement
    The input image to feed through the network.
 * **imageScaleFactor** - A number between 0.2 and 1.0. Defaults to 0.50.   What to scale the image by before feeding it through the network.  Set this number lower to scale down the image and increase the speed when feeding through the network at the cost of accuracy.
-* **reverse** - If the input image should be reversed horizontally.  Defaults to false. This is useful for video elements where the input image is usually reversed.
+* **flipHorizontal** - Defaults to false.  If the poses should be flipped/mirrored  horizontally.  This should be set to true for videos where the video is by default flipped horizontally (i.e. a webcam), and you want the poses to be returned in the proper orientation.
 * **outputStride** - the desired stride for the outputs when feeding the image through the model.  Must be 32, 16, 8.  Defaults to 16.  The higher the number, the faster the performance but slower the accuracy, and visa versa.
 
 #### Returns
@@ -92,12 +92,12 @@ It returns a `pose` with a confidence score and an array of keypoints indexed by
   <script>
     var imageScaleFactor = 0.5;
     var outputStride = 16;
-    var reverse = false;
+    var flipHorizontal = false;
 
     var imageElement = document.getElementById('cat');
 
     posenet.load().then(function(net){
-      return net.estimateSinglePose(imageElement, imageScaleFactor, reverse, outputStride)
+      return net.estimateSinglePose(imageElement, imageScaleFactor, flipHorizontal, outputStride)
     }).then(function(pose){
       console.log(pose);
     })
@@ -111,13 +111,13 @@ It returns a `pose` with a confidence score and an array of keypoints indexed by
 import * as posenet from '@tensorflow-models/posenet';
 const imageScaleFactor = 0.5;
 const outputStride = 16;
-const reverse = false;
+const flipHorizontal = false;
 
 async function estimatePoseOnImage(imageElement) {
   // load the posenet model from a checkpoint
   const net = await posenet.load();
 
-  const pose = await net.estimateSinglePose(imageElement, imageScaleFactor, reverse, outputStride);
+  const pose = await net.estimateSinglePose(imageElement, imageScaleFactor, flipHorizontal, outputStride);
 
   return pose;
 }
@@ -281,7 +281,7 @@ which would produce the output:
 Multiple Pose estimation can decode multiple poses in an image. It is more complex and slightly slower than the single pose-algorithm, but has the advantage that if multiple people appear in an image, their detected keypoints are less likely to be associated with the wrong pose. Even if the use case is to detect a single person’s pose, this algorithm may be more desirable in that the accidental effect of two poses being joined together won’t occur when multiple people appear in the image. It uses the `Fast greedy decoding` algorithm from the research paper [PersonLab: Person Pose Estimation and Instance Segmentation with a Bottom-Up, Part-Based, Geometric Embedding Model](https://arxiv.org/pdf/1803.08225.pdf).
 
 ```javascript
-const poses = await net.estimateMultiplePoses(image, imageScaleFactor, reverse, outputStride, maxPoseDetections, scoreThreshold, nmsRadius);
+const poses = await net.estimateMultiplePoses(image, imageScaleFactor, flipHorizontal, outputStride, maxPoseDetections, scoreThreshold, nmsRadius);
 ```
 
 #### Inputs
@@ -289,7 +289,7 @@ const poses = await net.estimateMultiplePoses(image, imageScaleFactor, reverse, 
 * **image** - ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement
    The input image to feed through the network.
 * **imageScaleFactor** - A number between 0.2 and 1.0. Defaults to 0.50.   What to scale the image by before feeding it through the network.  Set this number lower to scale down the image and increase the speed when feeding through the network at the cost of accuracy.
-* **reverse** - If the input image should be reversed horizontally.  Defaults to false. This is useful for video elements where the input image is usually reversed.
+* **flipHorizontal** - Defaults to false.  If the poses should be flipped/mirrored  horizontally.  This should be set to true for videos where the video is by default flipped horizontally (i.e. a webcam), and you want the poses to be returned in the proper orientation.
 * **outputStride** - the desired stride for the outputs when feeding the image through the model.  Must be 32, 16, 8.  Defaults to 16.  The higher the number, the faster the performance but slower the accuracy, and visa versa.
 * **maxPoseDetections** (optional) - the maximum number of poses to detect. Defaults to 5.
 * **scoreThreshold** (optional) - Only return instance detections that have root part score greater or equal to this value. Defaults to 0.5.
@@ -316,14 +316,14 @@ It returns a `promise` that resolves with an array of `poses`, each with a confi
   <!-- Place your code in the script tag below. You can also use an external .js file -->
   <script>
     var imageScaleFactor = 0.5;
-    var reverse = false;
+    var flipHorizontal = false;
     var outputStride = 16;
     var maxPoseDetections = 2;
 
     var imageElement = document.getElementById('cat');
 
     posenet.load().then(function(net){
-      return net.estimateMultiplePoses(imageElement, 0.5, reverse, outputStride, maxPoseDetections)
+      return net.estimateMultiplePoses(imageElement, 0.5, flipHorizontal, outputStride, maxPoseDetections)
     }).then(function(poses){
       console.log(poses);
     })
@@ -338,7 +338,7 @@ import * as posenet from '@tensorflow-models/posenet';
 
 const imageScaleFactor = 0.5;
 const outputStride = 16;
-const reverse = false;
+const flipHorizontal = false;
 const outputStride = 16;
 const maxPoseDetections = 2;
 
@@ -347,7 +347,7 @@ async function estimateMultiplePosesOnImage(imageElement) {
 
   // estimate poses
   const poses = await net.estimateMultiplePoses(imageElement,
-    imageScaleFactor, reverse, outputStride, maxPoseDetections);
+    imageScaleFactor, flipHorizontal, outputStride, maxPoseDetections);
 
   return poses;
 }

--- a/posenet/README.md
+++ b/posenet/README.md
@@ -57,14 +57,14 @@ All keypoints are indexed by part id.  The parts and their ids are:
 Single pose estimation is the simpler and faster of the two algorithms. Its ideal use case is for when there is only one person in the image. The disadvantage is that if there are multiple persons in an image, keypoints from both persons will likely be estimated as being part of the same single pose—meaning, for example, that person #1’s left arm and person #2’s right knee might be conflated by the algorithm as belonging to the same pose.
 
 ```javascript
-const pose = await poseNet.estimateSinglePose(image, resolution, reverse, outputStride);
+const pose = await poseNet.estimateSinglePose(image, imageScaleFactor, reverse, outputStride);
 ```
 
 #### Inputs
 
 * **image** - ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement
    The input image to feed through the network.
-* **resolution** - The resolution to scale the image to before feeding through the network. Defaults to 513.  Must have a value which when 1 is subtracted from it, is divisible by the output stride. Sample acceptable values are 29, 161, 193, 257, 289, 321, 353, 385, 417, 449, 481, 513. Set this number lower to scale down the image and increase the speed when feeding through the network.
+* **imageScaleFactor** - A number between 0.2 and 1.0. Defaults to 0.50.   What to scale the image by before feeding it through the network.  Set this number lower to scale down the image and increase the speed when feeding through the network at the cost of accuracy.
 * **reverse** - If the input image should be reversed horizontally.  Defaults to false. This is useful for video elements where the input image is usually reversed.
 * **outputStride** - the desired stride for the outputs when feeding the image through the model.  Must be 32, 16, 8.  Defaults to 16.  The higher the number, the faster the performance but slower the accuracy, and visa versa.
 
@@ -90,14 +90,14 @@ It returns a `pose` with a confidence score and an array of keypoints indexed by
   </body>
   <!-- Place your code in the script tag below. You can also use an external .js file -->
   <script>
-    var resolution = 321;
+    var imageScaleFactor = 0.5;
     var outputStride = 16;
     var reverse = false;
 
     var imageElement = document.getElementById('cat');
 
     posenet.load().then(function(net){
-      return net.estimateSinglePose(imageElement, resolution, reverse, outputStride)
+      return net.estimateSinglePose(imageElement, imageScaleFactor, reverse, outputStride)
     }).then(function(pose){
       console.log(pose);
     })
@@ -109,7 +109,7 @@ It returns a `pose` with a confidence score and an array of keypoints indexed by
 
 ```javascript
 import * as posenet from '@tensorflow-models/posenet';
-const resolution = 321;
+const imageScaleFactor = 0.5;
 const outputStride = 16;
 const reverse = false;
 
@@ -117,7 +117,7 @@ async function estimatePoseOnImage(imageElement) {
   // load the posenet model from a checkpoint
   const net = await posenet.load();
 
-  const pose = await net.estimateSinglePose(imageElement, resolution, reverse, outputStride);
+  const pose = await net.estimateSinglePose(imageElement, imageScaleFactor, reverse, outputStride);
 
   return pose;
 }
@@ -281,14 +281,14 @@ which would produce the output:
 Multiple Pose estimation can decode multiple poses in an image. It is more complex and slightly slower than the single pose-algorithm, but has the advantage that if multiple people appear in an image, their detected keypoints are less likely to be associated with the wrong pose. Even if the use case is to detect a single person’s pose, this algorithm may be more desirable in that the accidental effect of two poses being joined together won’t occur when multiple people appear in the image. It uses the `Fast greedy decoding` algorithm from the research paper [PersonLab: Person Pose Estimation and Instance Segmentation with a Bottom-Up, Part-Based, Geometric Embedding Model](https://arxiv.org/pdf/1803.08225.pdf).
 
 ```javascript
-const poses = await net.estimateMultiplePoses(image, resolution, reverse, outputStride, maxPoseDetections, scoreThreshold, nmsRadius);
+const poses = await net.estimateMultiplePoses(image, imageScaleFactor, reverse, outputStride, maxPoseDetections, scoreThreshold, nmsRadius);
 ```
 
 #### Inputs
 
 * **image** - ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement
    The input image to feed through the network.
-* **resolution** - The resolution to scale the image to before feeding through the network. Defaults to 513.  Must have a value which when 1 is subtracted from it, is divisible by the output stride. Sample acceptable values are 29, 161, 193, 257, 289, 321, 353, 385, 417, 449, 481, 513. Set this number lower to scale down the image and increase the speed feeding when through the network.
+* **imageScaleFactor** - A number between 0.2 and 1.0. Defaults to 0.50.   What to scale the image by before feeding it through the network.  Set this number lower to scale down the image and increase the speed when feeding through the network at the cost of accuracy.
 * **reverse** - If the input image should be reversed horizontally.  Defaults to false. This is useful for video elements where the input image is usually reversed.
 * **outputStride** - the desired stride for the outputs when feeding the image through the model.  Must be 32, 16, 8.  Defaults to 16.  The higher the number, the faster the performance but slower the accuracy, and visa versa.
 * **maxPoseDetections** (optional) - the maximum number of poses to detect. Defaults to 5.
@@ -315,7 +315,7 @@ It returns a `promise` that resolves with an array of `poses`, each with a confi
   </body>
   <!-- Place your code in the script tag below. You can also use an external .js file -->
   <script>
-    var resolution = 321;
+    var imageScaleFactor = 0.5;
     var reverse = false;
     var outputStride = 16;
     var maxPoseDetections = 2;
@@ -323,7 +323,7 @@ It returns a `promise` that resolves with an array of `poses`, each with a confi
     var imageElement = document.getElementById('cat');
 
     posenet.load().then(function(net){
-      return net.estimateMultiplePoses(imageElement, resolution, reverse, outputStride, maxPoseDetections)
+      return net.estimateMultiplePoses(imageElement, 0.5, reverse, outputStride, maxPoseDetections)
     }).then(function(poses){
       console.log(poses);
     })
@@ -336,7 +336,7 @@ It returns a `promise` that resolves with an array of `poses`, each with a confi
 ```javascript
 import * as posenet from '@tensorflow-models/posenet';
 
-const resolution = 321;
+const imageScaleFactor = 0.5;
 const outputStride = 16;
 const reverse = false;
 const outputStride = 16;
@@ -347,7 +347,7 @@ async function estimateMultiplePosesOnImage(imageElement) {
 
   // estimate poses
   const poses = await net.estimateMultiplePoses(imageElement,
-    resolution, reverse, outputStride, maxPoseDetections);
+    imageScaleFactor, reverse, outputStride, maxPoseDetections);
 
   return poses;
 }

--- a/posenet/demos/camera.html
+++ b/posenet/demos/camera.html
@@ -39,7 +39,7 @@
             <p>
                 PoseNet runs with either a <strong>single-pose</strong> or <strong>multi-pose</strong> detection algorithm. The single person pose detector is faster and more accurate but requires only one subject present in the image.
                 <br>
-                <br> The <strong>output stride</strong> and <strong>input image resolution</strong> have the largest effects on accuracy/speed. A <i>higher</i> output stride results in lower accuracy but higher speed. A <i>higher</i> input image resolution results in higher accuracy but lower speed.
+                <br> The <strong>output stride</strong> and <strong>image scale factor</strong> have the largest effects on accuracy/speed. A <i>higher</i> output stride results in lower accuracy but higher speed. A <i>higher</i> image scale factor results in higher accuracy but lower speed.
             </p>
         </div>
     </div>

--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -19,9 +19,6 @@ import Stats from 'stats.js';
 import * as posenet from '../src';
 
 import {drawKeypoints, drawSkeleton} from './demo_util';
-const maxStride = 32;
-const videoSizes = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].map(
-  (multiplier) => (maxStride * multiplier + 1));
 const maxVideoSize = 513;
 const canvasSize = 400;
 const stats = new Stats();
@@ -79,7 +76,7 @@ const guiState = {
   input: {
     mobileNetArchitecture: '1.01',
     outputStride: 16,
-    inputImageResolution: 225,
+    imageScaleFactor: 0.5,
   },
   singlePoseDetection: {
     minPoseConfidence: 0.1,
@@ -123,7 +120,7 @@ function setupGui(cameras, net) {
   const architectureController =
     input.add(guiState.input, 'mobileNetArchitecture', ['1.01', '1.00', '0.75', '0.50']);
   input.add(guiState.input, 'outputStride', [8, 16, 32]);
-  input.add(guiState.input, 'inputImageResolution', videoSizes);
+  input.add(guiState.input, 'imageScaleFactor').min(0.2).max(1.0);
   input.open();
 
   let single = gui.addFolder('Single Pose Detection');
@@ -187,7 +184,7 @@ function detectPoseInRealTime(video, net) {
 
     stats.begin();
 
-    const inputImageResolution = Number(guiState.input.inputImageResolution);
+    const imageScaleFactor = guiState.input.imageScaleFactor;
     const outputStride = Number(guiState.input.outputStride);
 
     let poses = [];
@@ -195,7 +192,7 @@ function detectPoseInRealTime(video, net) {
     let minPartConfidence;
     switch (guiState.algorithm) {
     case 'single-pose':
-      const pose = await guiState.net.estimateSinglePose(video, inputImageResolution, reverse, outputStride);
+      const pose = await guiState.net.estimateSinglePose(video, imageScaleFactor, reverse, outputStride);
       poses.push(pose);
 
       minPoseConfidence = Number(
@@ -204,7 +201,7 @@ function detectPoseInRealTime(video, net) {
         guiState.singlePoseDetection.minPartConfidence);
       break;
     case 'multi-pose':
-      poses = await guiState.net.estimateMultiplePoses(video, inputImageResolution, reverse, outputStride,
+      poses = await guiState.net.estimateMultiplePoses(video, imageScaleFactor, reverse, outputStride,
         guiState.multiPoseDetection.maxPoseDetections,
         guiState.multiPoseDetection.minPartConfidence,
         guiState.multiPoseDetection.nmsRadius);

--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -168,7 +168,7 @@ function setupFPS() {
 function detectPoseInRealTime(video, net) {
   const canvas = document.getElementById('output');
   const ctx = canvas.getContext('2d');
-  const reverse = true;
+  const flipHorizontal = true;
 
   canvas.width = canvasSize;
   canvas.height = canvasSize;
@@ -192,7 +192,7 @@ function detectPoseInRealTime(video, net) {
     let minPartConfidence;
     switch (guiState.algorithm) {
     case 'single-pose':
-      const pose = await guiState.net.estimateSinglePose(video, imageScaleFactor, reverse, outputStride);
+      const pose = await guiState.net.estimateSinglePose(video, imageScaleFactor, flipHorizontal, outputStride);
       poses.push(pose);
 
       minPoseConfidence = Number(
@@ -201,7 +201,7 @@ function detectPoseInRealTime(video, net) {
         guiState.singlePoseDetection.minPartConfidence);
       break;
     case 'multi-pose':
-      poses = await guiState.net.estimateMultiplePoses(video, imageScaleFactor, reverse, outputStride,
+      poses = await guiState.net.estimateMultiplePoses(video, imageScaleFactor, flipHorizontal, outputStride,
         guiState.multiPoseDetection.maxPoseDetections,
         guiState.multiPoseDetection.minPartConfidence,
         guiState.multiPoseDetection.nmsRadius);

--- a/posenet/demos/coco.js
+++ b/posenet/demos/coco.js
@@ -46,25 +46,6 @@ const images = [
   'two_on_bench.jpg',
 ];
 
-function toImageData(image) {
-  const [height, width] = image.shape;
-
-  const imageData = new ImageData(width, height);
-  const data = image.buffer().values;
-
-  for (let i = 0; i < height * width; i++) {
-    const j = i * 4;
-    const k = i * 4;
-
-    imageData.data[j + 0] = Math.round(255 * data[k + 0]);
-    imageData.data[j + 1] = Math.round(255 * data[k + 1]);
-    imageData.data[j + 2] = Math.round(255 * data[k + 2]);
-    imageData.data[j + 3] = Math.max(20, Math.round(255 * data[k + 3]));
-  }
-
-  return imageData;
-}
-
 function drawResults(canvas, poses,
   minPartConfidence, minPoseConfidence) {
   renderImageToCanvas(image, [513, 513], canvas);

--- a/posenet/src/mobilenet.ts
+++ b/posenet/src/mobilenet.ts
@@ -94,6 +94,15 @@ export function assertValidResolution(resolution: any, outputStride: number) {
           `${outputStride}.`);
 }
 
+export function assertValidScaleFactor(imageScaleFactor: any) {
+  tf.util.assert(
+      typeof imageScaleFactor === 'number', 'scaleFactor is not a number');
+
+  tf.util.assert(
+      imageScaleFactor <= 1.0, 'imageScaleFactor cannot be greater than 1.0')
+}
+
+
 export const mobileNetArchitectures:
     {[name: string]: ConvolutionDefinition[]} = {
       100: mobileNet100Architecture,

--- a/posenet/src/mobilenet.ts
+++ b/posenet/src/mobilenet.ts
@@ -96,10 +96,11 @@ export function assertValidResolution(resolution: any, outputStride: number) {
 
 export function assertValidScaleFactor(imageScaleFactor: any) {
   tf.util.assert(
-      typeof imageScaleFactor === 'number', 'scaleFactor is not a number');
+      typeof imageScaleFactor === 'number', 'imageScaleFactor is not a number');
 
   tf.util.assert(
-      imageScaleFactor <= 1.0, 'imageScaleFactor cannot be greater than 1.0')
+      imageScaleFactor >= 2.0 && imageScaleFactor <= 1.0,
+      'imageScaleFactor must be between 0.2 and 1.0')
 }
 
 

--- a/posenet/src/mobilenet.ts
+++ b/posenet/src/mobilenet.ts
@@ -99,7 +99,7 @@ export function assertValidScaleFactor(imageScaleFactor: any) {
       typeof imageScaleFactor === 'number', 'imageScaleFactor is not a number');
 
   tf.util.assert(
-      imageScaleFactor >= 2.0 && imageScaleFactor <= 1.0,
+      imageScaleFactor >= 0.2 && imageScaleFactor <= 1.0,
       'imageScaleFactor must be between 0.2 and 1.0')
 }
 

--- a/posenet/src/util.ts
+++ b/posenet/src/util.ts
@@ -18,6 +18,7 @@
 import * as tf from '@tensorflow/tfjs';
 
 import {connectedPartIndeces} from './keypoints';
+import {OutputStride} from './mobilenet';
 import {Keypoint, Pose, TensorBuffer3D, Vector2D} from './types';
 
 function eitherPointDoesntMeetConfidence(
@@ -97,4 +98,12 @@ export function scalePoses(poses: Pose[], scale: number): Pose[] {
     return poses;
   }
   return poses.map(pose => scalePose(pose, scale));
+}
+
+export function getValidResolution(
+    imageScaleFactor: number, inputDimension: number,
+    outputStride: OutputStride): number {
+  const evenResolution = inputDimension * imageScaleFactor - 1;
+
+  return evenResolution - (evenResolution % outputStride) + 1;
 }

--- a/posenet/src/util_test.ts
+++ b/posenet/src/util_test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {getValidResolution} from './util'
+
+describe('util', () => {
+  describe('getValidResolution', () => {
+    it('returns an odd value', () => {
+      expect(getValidResolution(0.5, 545, 32) % 2).toEqual(1);
+      expect(getValidResolution(0.5, 545, 16) % 2).toEqual(1);
+      expect(getValidResolution(0.5, 545, 8) % 2).toEqual(1);
+      expect(getValidResolution(0.845, 242, 8) % 2).toEqual(1);
+      expect(getValidResolution(0.421, 546, 16) % 2).toEqual(1);
+    })
+
+    it('returns a value that when 1 is subtracted by it is ' +
+           'divisible by the output stride',
+       () => {
+         const outputStride = 32;
+         const imageSize = 562;
+
+         const scaleFactor = 0.63;
+
+         const resolution =
+             getValidResolution(scaleFactor, imageSize, outputStride);
+
+         expect((resolution - 1) % outputStride).toEqual(0);
+       });
+  });
+});


### PR DESCRIPTION
* Changed from using an input image resolution to an `imageScaleFactor`

This results in calculation a resolution that would satisfy both the imageScaleFactor and having its odd value be divisible by the output stride.

* Changed the parameter reverse to `flipHorizontal`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/6)
<!-- Reviewable:end -->
