### PR TITLE
Fixed camera demo for IOS safari

### DIFF
--- a/posenet/demos/camera.html
+++ b/posenet/demos/camera.html
@@ -17,15 +17,23 @@
         text-align: center;
         margin: auto;
     }
+
+    @media only screen and (max-width: 600px) {
+      .footer-text, .dg {
+        display: none;
+      }
+    }
     </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
 <body>
     <div id="loading">
         Loading the model...
     </div>
+
     <div id='main' style='display:none'>
-        <video autoplay="true" id="video" style=" -moz-transform: scaleX(-1);
+        <video id="video" playsinline style=" -moz-transform: scaleX(-1);
         -o-transform: scaleX(-1);
         -webkit-transform: scaleX(-1);
         transform: scaleX(-1);

--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -27,12 +27,12 @@ function isAndroid() {
   return /Android/i.test(navigator.userAgent);
 }
 
-function isOS() {
+function isiOS() {
   return /iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
 function isMobile() {
-  return isAndroid() || isOS();
+  return isAndroid() || isiOS();
 }
 
 /**
@@ -61,7 +61,9 @@ async function setupCamera() {
       };
     });
   } else {
-    throw new Error("This browser does not support video capture.");
+    const errorMessage = "This browser does not support video capture, or this device does not have a camera";
+    alert(errorMessage);
+    return Promise.reject(errorMessage);
   }
 }
 
@@ -290,7 +292,7 @@ export async function bindPage() {
   try {
     video = await loadVideo();
   } catch(e) {
-    alert(e);
+    console.error(e);
     return;
   }
 

--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -32,7 +32,7 @@ function isOS() {
 }
 
 function isMobile() {
-  isAndroid() || isOS();
+  return isAndroid() || isOS();
 }
 
 /**

--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -23,70 +23,59 @@ const maxVideoSize = 513;
 const canvasSize = 400;
 const stats = new Stats();
 
-/**
- * Gets all available media devices and filters for only video devices
- */
-async function getCameras() {
-  const devices = await navigator.mediaDevices.enumerateDevices();
-  return devices.filter(({ kind }) => kind === 'videoinput');
+function isAndroid() {
+  return /Android/i.test(navigator.userAgent);
 }
 
-let currentStream = null;
+function isOS() {
+  return /iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+function isMobile() {
+  isAndroid() || isOS();
+}
 
 /**
- * Stops the video stream permanently
+ * Loads a the camera to be used in the demo
+ *
  */
-function stopCurrentVideoStream() {
-  if (currentStream) {
-    currentStream.getTracks().forEach((track) => {
-      track.stop();
+async function setupCamera() {
+  const video = document.getElementById('video');
+  video.width = maxVideoSize;
+  video.height = maxVideoSize;
+
+  if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+    const mobile = isMobile();
+    const stream = await navigator.mediaDevices.getUserMedia({
+      'audio': false,
+      'video': {
+        facingMode: 'user',
+        width: mobile ? undefined : maxVideoSize,
+        height: mobile ? undefined: maxVideoSize}
     });
+    video.srcObject = stream;
+
+    return new Promise(resolve => {
+      video.onloadedmetadata = () => {
+        resolve(video);
+      };
+    });
+  } else {
+    throw new Error("This browser does not support video capture.");
   }
 }
 
-/**
- * Loads a video based on a device ID
- *
- * @param {number} a video media device ID
- */
-function loadVideo(cameraId) {
-  return new Promise((resolve, reject) => {
-    stopCurrentVideoStream();
+async function loadVideo() {
+  const video = await setupCamera();
+  video.play();
 
-    const video = document.getElementById('video');
-
-    // Important to note that the image fed into posenet must be square
-    video.width = maxVideoSize;
-    video.height = maxVideoSize;
-
-    if (navigator.getUserMedia) {
-      navigator.getUserMedia({
-        video: {
-          width: maxVideoSize,
-          height: maxVideoSize,
-          deviceId: { exact: cameraId },
-        },
-      }, handleVideo, videoError);
-    }
-
-    function handleVideo(stream) {
-      currentStream = stream;
-      video.srcObject = stream;
-
-      resolve(video);
-    }
-
-    function videoError(e) {
-      // do something
-      reject(e);
-    }
-  });
+  return video;
 }
 
 const guiState = {
   algorithm: 'single-pose',
   input: {
-    mobileNetArchitecture: '1.01',
+    mobileNetArchitecture: isMobile() ? '0.50' : '1.01',
     outputStride: 16,
     imageScaleFactor: 0.5,
   },
@@ -125,9 +114,6 @@ function setupGui(cameras, net) {
 
   const gui = new dat.GUI({ width: 300 });
 
-  gui.add(guiState, 'camera', cameraOptions).onChange((deviceId) => {
-    loadVideo(deviceId);
-  });
   // The single-pose algorithm is faster and simpler but requires only one person to be
   // in the frame or results will be innaccurate. Multi-pose works for more than 1 person
   const algorithmController = gui.add(
@@ -258,7 +244,8 @@ function detectPoseInRealTime(video, net) {
     if (guiState.output.showVideo) {
       ctx.save();
       ctx.scale(-1, 1);
-      ctx.drawImage(video, 0, 0, canvasSize * -1, canvasSize);
+      ctx.translate(-canvasSize, 0);
+      ctx.drawImage(video, 0, 0, canvasSize, canvasSize);
       ctx.restore();
     }
 
@@ -298,16 +285,16 @@ export async function bindPage() {
   document.getElementById('loading').style.display = 'none';
   document.getElementById('main').style.display = 'block';
 
-  const cameras = await getCameras();
+  let video;
 
-  if (cameras.length === 0) {
-    alert('No webcams available.  Reload the page when a webcam is available.');
+  try {
+    video = await loadVideo();
+  } catch(e) {
+    alert(e);
     return;
   }
 
-  const video = await loadVideo(cameras[0].deviceId);
-
-  setupGui(cameras, net);
+  setupGui([], net);
   setupFPS();
   detectPoseInRealTime(video, net);
 }


### PR DESCRIPTION
* Made camera demo responsive for mobile - by using media query device
width meta tag.

* For mobile devices, defaulting to use mobile net multiplier 0.50

* Selecting camera using the modern api.  raising an error  if that api
doesn't exist on that browser

* Fixed mirroring of output image on ios.

* Got rid of gui for safari mobile since it clogs up the view . Just defaulting to single pose. Hiding the footer text on responsive mobile since it describes options that are no longer visible.

* Got rid of being able to switch camera since when using rear facing camera the mirroring is missed up.  In the future, will add that back in when we can fix the mirroring issues for rear facing camera.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/10)
<!-- Reviewable:end -->
