### PR TITLE
Fix `@tensorflow-models` CDN url

### DIFF
--- a/mobilenet/README.md
+++ b/mobilenet/README.md
@@ -22,7 +22,7 @@ There are two main ways to get this model in your JavaScript project: via script
 <!-- Load TensorFlow.js. This is required to use MobileNet. -->
 <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@0.10.3"> </script>
 <!-- Load the MobileNet model. -->
-<script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@0.1.0"> </script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@0.0.1"> </script>
 
 <!-- Replace this with your image. Make sure CORS settings allow reading the image! -->
 <img id="img" src="cat.jpg"></img>

--- a/mobilenet/README.md
+++ b/mobilenet/README.md
@@ -20,9 +20,9 @@ There are two main ways to get this model in your JavaScript project: via script
 
 ```html
 <!-- Load TensorFlow.js. This is required to use MobileNet. -->
-<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@0.10.3"> </script>
+<script src="https://unpkg.com/@tensorflow/tfjs@0.10.3"> </script>
 <!-- Load the MobileNet model. -->
-<script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@0.0.1"> </script>
+<script src="https://unpkg.com/@tensorflow-models/mobilenet@0.0.1"> </script>
 
 <!-- Replace this with your image. Make sure CORS settings allow reading the image! -->
 <img id="img" src="cat.jpg"></img>


### PR DESCRIPTION
The CDN url for `https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@0.1.0` should be `@0.0.1`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/14)
<!-- Reviewable:end -->
