### PR TITLE
Added assertions to the dimensions of the input to the neural net.

### DIFF
--- a/posenet/src/mobilenet.ts
+++ b/posenet/src/mobilenet.ts
@@ -104,13 +104,13 @@ export function assertValidScaleFactor(imageScaleFactor: any) {
       'imageScaleFactor must be between 0.2 and 1.0')
 }
 
-export function assertValidDimensions(inputType: InputType) {
+export function assertValidDimensions(input: InputType) {
   tf.util.assert(
-    typeof inputType.width === 'number' && inputType.width > 0,
+    typeof input.width === 'number' && input.width > 0,
     'The width of the input must be a number greater than 0');
 
   tf.util.assert(
-    typeof inputType.height === 'number' && inputType.height > 0,
+    typeof input.height === 'number' && input.height > 0,
     'The height of the input must be a number greater than 0');
 }
 

--- a/posenet/src/mobilenet.ts
+++ b/posenet/src/mobilenet.ts
@@ -16,6 +16,7 @@
  */
 
 import * as tf from '@tensorflow/tfjs';
+import { InputType } from './posenet';
 
 export type MobileNetMultiplier = 0.50|0.75|1.0|1.01;
 export type ConvolutionType = 'conv2d'|'separableConv';
@@ -103,6 +104,15 @@ export function assertValidScaleFactor(imageScaleFactor: any) {
       'imageScaleFactor must be between 0.2 and 1.0')
 }
 
+export function assertValidDimensions(inputType: InputType) {
+  tf.util.assert(
+    typeof inputType.width === 'number' && inputType.width > 0,
+    'The width of the input must be a number greater than 0');
+
+  tf.util.assert(
+    typeof inputType.height === 'number' && inputType.height > 0,
+    'The height of the input must be a number greater than 0');
+}
 
 export const mobileNetArchitectures:
     {[name: string]: ConvolutionDefinition[]} = {

--- a/posenet/src/posenet.ts
+++ b/posenet/src/posenet.ts
@@ -19,7 +19,7 @@ import * as tf from '@tensorflow/tfjs';
 
 import { CheckpointLoader } from './checkpoint_loader';
 import { checkpoints } from './checkpoints';
-import { assertValidOutputStride, assertValidScaleFactor, MobileNet, MobileNetMultiplier, OutputStride } from './mobilenet';
+import { assertValidOutputStride, assertValidScaleFactor, assertValidDimensions, MobileNet, MobileNetMultiplier, OutputStride } from './mobilenet';
 import decodeMultiplePoses from './multiPose/decodeMultiplePoses';
 import decodeSinglePose from './singlePose/decodeSinglePose';
 import { Pose } from './types';
@@ -146,6 +146,7 @@ export class PoseNet {
     input: InputType, imageScaleFactor: number = 0.5,
     flipHorizontal: boolean = false,
     outputStride: OutputStride = 16): Promise<Pose> {
+    assertValidDimensions(input);
     assertValidOutputStride(outputStride);
     assertValidScaleFactor(imageScaleFactor);
     const resizedHeight =
@@ -212,6 +213,7 @@ export class PoseNet {
     input: InputType, imageScaleFactor: number = 0.5,
     flipHorizontal: boolean = false, outputStride: OutputStride = 16,
     maxDetections = 5, scoreThreshold = .5, nmsRadius = 20): Promise<Pose[]> {
+    assertValidDimensions(input);
     assertValidOutputStride(outputStride);
     assertValidScaleFactor(imageScaleFactor);
     const resizedHeight =


### PR DESCRIPTION
Previously if you passed an input with width or height 0, TensorFlow fromPixels would error because the requested size would be an invalid texture. This wasn't intuitive to the user of the API. These asserts help with catching the error earlier and present it to the end user in a better fashion.

This issue was raised and discussed here: https://github.com/tensorflow/tfjs/issues/322

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/23)
<!-- Reviewable:end -->
