### PR TITLE
Export more types, methods, and classes of posenet

### DIFF
--- a/posenet/src/index.ts
+++ b/posenet/src/index.ts
@@ -15,14 +15,25 @@
  * =============================================================================
  */
 
+import {CheckpointLoader} from './checkpoint_loader';
+// tslint:disable-next-line:max-line-length
+import {ConvolutionDefinition, MobileNet, mobileNetArchitectures, MobileNetMultiplier, OutputStride} from './mobilenet';
 import {decodeMultiplePoses} from './multiPose/decodeMultiplePoses';
 import {load, PoseNet} from './posenet_model';
 import {decodeSinglePose} from './singlePose/decodeSinglePose';
 
-export {checkpoints} from './checkpoints';
+export {Checkpoint} from './checkpoints';
 export {partIds, partNames, poseChain} from './keypoints';
 export {Keypoint, Pose} from './types';
 // tslint:disable-next-line:max-line-length
 export {getAdjacentKeyPoints, getBoundingBox, getBoundingBoxPoints} from './util';
+export {
+  ConvolutionDefinition,
+  MobileNet,
+  mobileNetArchitectures,
+  MobileNetMultiplier,
+  OutputStride
+};
+export {CheckpointLoader};
 export {decodeMultiplePoses, decodeSinglePose};
 export {load, PoseNet};


### PR DESCRIPTION
This way they can be used in pieces allowing for more customization, such as loading from
a different url.

For example, with this pr you can create this function to load from a different url:

```typescript
import * as posenet from '@tensorflow-models/posenet';

async function loadModel(url: string, architecture: posenet.ConvolutionDefinition[], multiplier: posenet.MobileNetMultiplier):
    Promise<posenet.PoseNet> {
  const checkpointLoader = new posenet.CheckpointLoader(url);

  const variables = await checkpointLoader.getAllVariables();

  const mobileNetModel = new posenet.MobileNet(variables, architecture);

  return new posenet.PoseNet(url, mobileNetModel);
}
```