### PR TITLE
Fix typo in the KNNClassifier

### DIFF
--- a/knn-classifier/src/index.ts
+++ b/knn-classifier/src/index.ts
@@ -134,7 +134,7 @@ export class KNNClassifier {
     }
     if (this.getNumExamples() === 0) {
       throw new Error(
-          `You have not added any exaples to the KNN classifier. ` +
+          `You have not added any examples to the KNN classifier. ` +
           `Please add examples before calling predictClass.`);
     }
     const knn = tf.tidy(() => this.similarities(input).asType('float32'));

--- a/knn-classifier/src/index_test.ts
+++ b/knn-classifier/src/index_test.ts
@@ -61,6 +61,6 @@ describeWithFlags('KNNClassifier', tf.test_util.NODE_ENVS, () => {
       errorMessage = error.message;
     }
     expect(errorMessage)
-        .toMatch(/You have not added any exaples to the KNN classifier/);
+        .toMatch(/You have not added any examples to the KNN classifier/);
   });
 });


### PR DESCRIPTION
Fix typo in the KNNClassifier,

`s/exaples/examples/g`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/67)
<!-- Reviewable:end -->
