### PR TITLE
[speech-commands]  Add versioning and release infra 

### DIFF
--- a/speech-commands/README.md
+++ b/speech-commands/README.md
@@ -37,6 +37,7 @@ To use the speech-command recognizer, first create a recognizer instance,
 then start the streaming recognition by calling its `startStreaming()` method.
 
 ```js
+import * as tf from '@tensorflow/tfjs';
 import * as SpeechCommands from '@tensorflow-models/speech-commands';
 
 // When calling `create()`, you must provide the type of the audio input.

--- a/speech-commands/README.md
+++ b/speech-commands/README.md
@@ -38,14 +38,14 @@ then start the streaming recognition by calling its `startStreaming()` method.
 
 ```js
 import * as tf from '@tensorflow/tfjs';
-import * as SpeechCommands from '@tensorflow-models/speech-commands';
+import * as speechCommands from '@tensorflow-models/speech-commands';
 
 // When calling `create()`, you must provide the type of the audio input.
 // The two available options are `BROWSER_FFT` and `SOFT_FFT`.
 // - BROWSER_FFT uses the browser's native Fourier transform.
 // - SOFT_FFT uses JavaScript implementations of Fourier transform
 //   (not implemented yet).
-const recognizer = SpeechCommands.create('BROWSER_FFT');
+const recognizer = speechCommands.create('BROWSER_FFT');
 
 // See the array of words that the recognizer is trained to recognize.
 console.log(recognizer.wordLabels());
@@ -94,9 +94,9 @@ E.g.,
 
 ```js
 import * as tf from '@tensorflow/tfjs';
-import * as SpeechCommands from '@tensorflow-models/speech-commands';
+import * as speechCommands from '@tensorflow-models/speech-commands';
 
-const recognizer = SpeechCommands.create('BROWSER_FFT');
+const recognizer = speechCommands.create('BROWSER_FFT');
 
 // Inspect the input shape of the recognizer's underlying tf.Model.
 console.log(recognizer.modelInputShape());
@@ -157,7 +157,7 @@ this type of transfer learning. The steps are listed in the example
 code snippet below
 
 ```js
-const baseRecognizer = SpeechCommands.create('BROWSER_FFT');
+const baseRecognizer = speechCommands.create('BROWSER_FFT');
 await baseRecognizer.ensureModelLoaded();
 
 // Each instance of speech-command recognizer supports multiple

--- a/speech-commands/README.md
+++ b/speech-commands/README.md
@@ -47,6 +47,10 @@ import * as speechCommands from '@tensorflow-models/speech-commands';
 //   (not implemented yet).
 const recognizer = speechCommands.create('BROWSER_FFT');
 
+// Make sure that the underlying model and metadata are loaded via HTTPS
+// requests.
+await recognizer.ensureModelLoaded();
+
 // See the array of words that the recognizer is trained to recognize.
 console.log(recognizer.wordLabels());
 
@@ -73,6 +77,10 @@ setTimeout(() => recognizer.stopStreaming(), 10e3);
 As the example above shows, you can specify optional parameters when calling
 `startStreaming()`. The supported parameters are:
 
+* `overlapFactor`: Controls how often the recognizer performs predicton on
+  spectrograms. Must be a number between 0 and 1 (default: 0.5). For example,
+  if each spectrogram is 1000 ms long and `overlapFactor` is set to 0.25,
+  the prediction will happen every 250 ms.
 * `includeSpectrogram`: Let the callback function be invoked with the
   spectrogram data included in the argument. Default: `false`.
 * `probabilityThreshold`: The callback function will be invoked if and only if

--- a/speech-commands/demo/index.html
+++ b/speech-commands/demo/index.html
@@ -157,7 +157,7 @@
     <div id="collect-words"></div>
     <div class="settings">
       <span>Epochs:</span>
-      <input class="settings" size="5" id="epochs" value="20">
+      <input class="settings" size="5" id="epochs" value="40">
       <button id="start-transfer-learn" disabled="true">Start transfer learning</button>
     </div>
     <div id="plots">

--- a/speech-commands/demo/package.json
+++ b/speech-commands/demo/package.json
@@ -9,7 +9,7 @@
       "node": ">=8.9.0"
     },
     "dependencies": {
-      "@tensorflow/tfjs": "^0.12.5",
+      "@tensorflow/tfjs": "0.12.6",
       "stats.js": "^0.17.0"
     },
     "scripts": {

--- a/speech-commands/demo/package.json
+++ b/speech-commands/demo/package.json
@@ -9,7 +9,7 @@
       "node": ">=8.9.0"
     },
     "dependencies": {
-      "@tensorflow/tfjs": "0.12.7",
+      "@tensorflow/tfjs": "^0.12.7",
       "stats.js": "^0.17.0"
     },
     "scripts": {

--- a/speech-commands/demo/package.json
+++ b/speech-commands/demo/package.json
@@ -9,7 +9,7 @@
       "node": ">=8.9.0"
     },
     "dependencies": {
-      "@tensorflow/tfjs": "0.12.6",
+      "@tensorflow/tfjs": "0.12.7",
       "stats.js": "^0.17.0"
     },
     "scripts": {

--- a/speech-commands/demo/yarn.lock
+++ b/speech-commands/demo/yarn.lock
@@ -45,33 +45,33 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.5.7.tgz#b4b1a49cf90b5106a4351f1941c77c52f3f22ce9"
+"@tensorflow/tfjs-converter@0.5.9":
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.5.9.tgz#76913bd916bbd940b6435e9e3ec63f963c786b95"
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.12.11":
-  version "0.12.11"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.11.tgz#8da98fae720e58a484315d2e72d0c858991e4aee"
+"@tensorflow/tfjs-core@0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.15.tgz#b6c09dfe99cffd298745a694347b29a2c5aa9871"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"
     "@types/webgl2" "~0.0.4"
     seedrandom "~2.4.3"
 
-"@tensorflow/tfjs-layers@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.4.tgz#575a3bc2c895501c619b4b7102b4e17256c30835"
+"@tensorflow/tfjs-layers@0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.5.tgz#54241110e0a6e194eafbbd18babca0978788e930"
 
-"@tensorflow/tfjs@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.5.tgz#60d449457c99b661b4dce9e665e97f2476bc544c"
+"@tensorflow/tfjs@0.12.6":
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.6.tgz#a77f62941e58aca097ac863b9dba22ed786322f5"
   dependencies:
-    "@tensorflow/tfjs-converter" "0.5.7"
-    "@tensorflow/tfjs-core" "0.12.11"
-    "@tensorflow/tfjs-layers" "0.7.4"
+    "@tensorflow/tfjs-converter" "0.5.9"
+    "@tensorflow/tfjs-core" "0.12.15"
+    "@tensorflow/tfjs-layers" "0.7.5"
 
 "@types/long@^4.0.0":
   version "4.0.0"

--- a/speech-commands/demo/yarn.lock
+++ b/speech-commands/demo/yarn.lock
@@ -52,9 +52,9 @@
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.12.15":
-  version "0.12.15"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.15.tgz#b6c09dfe99cffd298745a694347b29a2c5aa9871"
+"@tensorflow/tfjs-core@0.12.17":
+  version "0.12.17"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.17.tgz#133fef53272e4dc0819890e79153c8ee094400b6"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"
@@ -65,12 +65,12 @@
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.5.tgz#54241110e0a6e194eafbbd18babca0978788e930"
 
-"@tensorflow/tfjs@0.12.6":
-  version "0.12.6"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.6.tgz#a77f62941e58aca097ac863b9dba22ed786322f5"
+"@tensorflow/tfjs@0.12.7":
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.7.tgz#2fb643f503dada14b7f0ca43d2a41082b626f92a"
   dependencies:
     "@tensorflow/tfjs-converter" "0.5.9"
-    "@tensorflow/tfjs-core" "0.12.15"
+    "@tensorflow/tfjs-core" "0.12.17"
     "@tensorflow/tfjs-layers" "0.7.5"
 
 "@types/long@^4.0.0":

--- a/speech-commands/demo/yarn.lock
+++ b/speech-commands/demo/yarn.lock
@@ -65,7 +65,7 @@
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.5.tgz#54241110e0a6e194eafbbd18babca0978788e930"
 
-"@tensorflow/tfjs@0.12.7":
+"@tensorflow/tfjs@^0.12.7":
   version "0.12.7"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.7.tgz#2fb643f503dada14b7f0ca43d2a41082b626f92a"
   dependencies:

--- a/speech-commands/make-version
+++ b/speech-commands/make-version
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Copyright 2018 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// =============================================================================
+
+// Run this script from the base directory (not the script directory):
+// ./scripts/make-version
+
+const fs = require('fs');
+const version = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+
+const versionCode =
+`/** @license See the LICENSE file. */
+// This code is auto-generated, do not modify this file!
+const version = '${version}';
+export {version};
+`
+
+fs.writeFile('src/version.ts', versionCode, err => {
+  if (err) {
+    throw new Error(`Could not save version file ${version} : $ { err }`);
+  }
+  console.log(`Version file for version ${version} saved sucessfully.`);
+});

--- a/speech-commands/package.json
+++ b/speech-commands/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs": "^0.12.5"
+    "@tensorflow/tfjs": "0.12.6"
   },
   "devDependencies": {
-    "@tensorflow/tfjs": "^0.12.5",
+    "@tensorflow/tfjs": "0.12.6",
     "@types/jasmine": "~2.8.8",
     "babel-core": "~6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",
@@ -34,7 +34,7 @@
     "yalc": "~1.0.0-pre.21"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rimraf dist && tsc && rollup -c",
     "lint": "tslint -p . -t verbose",
     "publish-local": "yarn build && yalc push",
     "test": "yarn build && ts-node run_tests.ts"

--- a/speech-commands/package.json
+++ b/speech-commands/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs": "0.12.6"
+    "@tensorflow/tfjs": "0.12.7"
   },
   "devDependencies": {
-    "@tensorflow/tfjs": "0.12.6",
+    "@tensorflow/tfjs": "0.12.7",
     "@types/jasmine": "~2.8.8",
     "babel-core": "~6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",

--- a/speech-commands/package.json
+++ b/speech-commands/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs": "0.12.7"
+    "@tensorflow/tfjs": "^0.12.7"
   },
   "devDependencies": {
-    "@tensorflow/tfjs": "0.12.7",
+    "@tensorflow/tfjs": "^0.12.7",
     "@types/jasmine": "~2.8.8",
     "babel-core": "~6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",

--- a/speech-commands/package.json
+++ b/speech-commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/speech-commands",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Speech-command recognizer in TensorFlow.js",
   "main": "dist/index.js",
   "unpkg": "dist/speech-commands.min.js",

--- a/speech-commands/rollup.config.js
+++ b/speech-commands/rollup.config.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import node from 'rollup-plugin-node-resolve';
+import typescript from 'rollup-plugin-typescript2';
+import uglify from 'rollup-plugin-uglify';
+
+const PREAMBLE =
+  `// @tensorflow/tfjs-models Copyright ${(new Date).getFullYear()} Google`;
+
+function minify() {
+  return uglify({
+    output: {
+      preamble: PREAMBLE
+    }
+  });
+}
+
+function config({
+  plugins = [],
+  output = {}
+}) {
+  return {
+    input: 'src/index.ts',
+    plugins: [
+      typescript({
+        tsconfigOverride: {
+          compilerOptions: {
+            module: 'ES2015'
+          }
+        }
+      }),
+      node(), ...plugins
+    ],
+    output: {
+      banner: PREAMBLE,
+      globals: {
+        '@tensorflow/tfjs': 'tf'
+      },
+      ...output
+    },
+    external: ['@tensorflow/tfjs']
+  };
+}
+
+export default [
+  config({
+    output: {
+      format: 'umd',
+      name: 'SpeechCommands',
+      file: 'dist/speech-commands.js'
+    }
+  }),
+  config({
+    plugins: [minify()],
+    output: {
+      format: 'umd',
+      name: 'SpeechCommands',
+      file: 'dist/speech-commands.min.js'
+    }
+  }),
+  config({
+    plugins: [minify()],
+    output: {
+      format: 'es',
+      file: 'dist/speech-commands.esm.js'
+    }
+  })
+];

--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -21,6 +21,7 @@ import * as tf from '@tensorflow/tfjs';
 import {BrowserFftFeatureExtractor, SpectrogramCallback} from './browser_fft_extractor';
 import {loadMetadataJson} from './browser_fft_utils';
 import {RecognizerCallback, RecognizerParams, SpectrogramData, SpeechCommandRecognizer, SpeechCommandRecognizerResult, StreamingRecognitionConfig, TransferLearnConfig, TransferSpeechCommandRecognizer} from './types';
+import {version} from './version';
 
 // tslint:enable:max-line-length
 
@@ -36,9 +37,9 @@ export class BrowserFftSpeechCommandRecognizer implements
     SpeechCommandRecognizer {
   // tslint:disable:max-line-length
   readonly DEFAULT_MODEL_JSON_URL =
-      'https://storage.googleapis.com/tfjs-speech-commands-models/20w/model.json';
+      `https://storage.googleapis.com/tfjs-speech-commands-models/v${version}/20w/model.json`;
   readonly DEFAULT_METADATA_JSON_URL =
-      'https://storage.googleapis.com/tfjs-speech-commands-models/20w/metadata.json';
+      `https://storage.googleapis.com/tfjs-speech-commands-models/v${version}/20w/metadata.json`;
   // tslint:enable:max-line-length
 
   private readonly SAMPLE_RATE_HZ = 44100;

--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -37,9 +37,9 @@ export class BrowserFftSpeechCommandRecognizer implements
     SpeechCommandRecognizer {
   // tslint:disable:max-line-length
   readonly DEFAULT_MODEL_JSON_URL =
-      `https://storage.googleapis.com/tfjs-speech-commands-models/v${version}/20w/model.json`;
+      `https://storage.googleapis.com/tfjs-speech-commands-models/v${version}/browser_fft/20w/model.json`;
   readonly DEFAULT_METADATA_JSON_URL =
-      `https://storage.googleapis.com/tfjs-speech-commands-models/v${version}/20w/metadata.json`;
+      `https://storage.googleapis.com/tfjs-speech-commands-models/v${version}/browser_fft/20w/metadata.json`;
   // tslint:enable:max-line-length
 
   private readonly SAMPLE_RATE_HZ = 44100;

--- a/speech-commands/src/index.ts
+++ b/speech-commands/src/index.ts
@@ -41,3 +41,4 @@ export function create(fftType: FFT_TYPE): SpeechCommandRecognizer {
 // tslint:disable-next-line:max-line-length
 export {FFT_TYPE, RecognizerParams, SpectrogramData, SpeechCommandRecognizerResult, StreamingRecognitionConfig, TransferLearnConfig} from './types';
 export {BACKGROUND_NOISE_TAG, UNKNOWN_TAG} from  './browser_fft_recognizer';
+export {version} from './version';

--- a/speech-commands/src/index_test.ts
+++ b/speech-commands/src/index_test.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as SpeechCommands from './index';
+
+describe('Public API', () => {
+  it('version is available', () => {
+    expect(typeof SpeechCommands.version).toEqual('string');
+    expect(SpeechCommands.version.length).toBeGreaterThan(0);
+  });
+});

--- a/speech-commands/src/index_test.ts
+++ b/speech-commands/src/index_test.ts
@@ -16,11 +16,11 @@
  */
 
 const packageJSON = require('../package.json');
-import * as SpeechCommands from './index';
+import * as speechCommands from './index';
 
 describe('Public API', () => {
   it('version matches package.json', () => {
-    expect(typeof SpeechCommands.version).toEqual('string');
-    expect(SpeechCommands.version).toEqual(packageJSON.version);
+    expect(typeof speechCommands.version).toEqual('string');
+    expect(speechCommands.version).toEqual(packageJSON.version);
   });
 });

--- a/speech-commands/src/index_test.ts
+++ b/speech-commands/src/index_test.ts
@@ -15,11 +15,12 @@
  * =============================================================================
  */
 
+const packageJSON = require('../package.json');
 import * as SpeechCommands from './index';
 
 describe('Public API', () => {
-  it('version is available', () => {
+  it('version matches package.json', () => {
     expect(typeof SpeechCommands.version).toEqual('string');
-    expect(SpeechCommands.version.length).toBeGreaterThan(0);
+    expect(SpeechCommands.version).toEqual(packageJSON.version);
   });
 });

--- a/speech-commands/src/types.ts
+++ b/speech-commands/src/types.ts
@@ -31,6 +31,13 @@ export type RecognizerCallback = (result: SpeechCommandRecognizerResult) =>
  */
 export interface SpeechCommandRecognizer {
   /**
+   * Load the underlying model instance and associated metadata.
+   *
+   * If the model and the metadata are already loaded, do nothing.
+   */
+  ensureModelLoaded(): Promise<void>;
+
+  /**
    * Start recognition in a streaming fashion.
    *
    * @param callback the callback that will be invoked every time
@@ -39,8 +46,8 @@ export interface SpeechCommandRecognizer {
    * @throws Error if there is already ongoing streaming recognition.
    */
   startStreaming(
-    callback: RecognizerCallback,
-    config?: StreamingRecognitionConfig): Promise<void>;
+      callback: RecognizerCallback,
+      config?: StreamingRecognitionConfig): Promise<void>;
 
   /**
    *  Stop the ongoing streaming recognition (if any).
@@ -106,8 +113,8 @@ export interface SpeechCommandRecognizer {
  * querying the status of example collection, and for performing the
  * transfer-learning training.
  */
-export interface TransferSpeechCommandRecognizer
-    extends SpeechCommandRecognizer {
+export interface TransferSpeechCommandRecognizer extends
+    SpeechCommandRecognizer {
   /**
    * Collect an example for transfer learning via WebAudio.
    *
@@ -255,7 +262,7 @@ export interface TransferLearnConfig {
   /**
    * Optimizer to be used for training (default: 'sgd').
    */
-  optimizer?: string | tf.Optimizer;
+  optimizer?: string|tf.Optimizer;
 
   /**
    * Batch size of training (default: 128).

--- a/speech-commands/src/version.ts
+++ b/speech-commands/src/version.ts
@@ -1,4 +1,4 @@
 /** @license See the LICENSE file. */
 // This code is auto-generated, do not modify this file!
-const version = '0.1.0';
+const version = '0.1.1';
 export {version};

--- a/speech-commands/src/version.ts
+++ b/speech-commands/src/version.ts
@@ -1,0 +1,4 @@
+/** @license See the LICENSE file. */
+// This code is auto-generated, do not modify this file!
+const version = '0.1.0';
+export {version};

--- a/speech-commands/tsconfig.json
+++ b/speech-commands/tsconfig.json
@@ -21,5 +21,12 @@
   },
   "include": [
     "src/**/*"
+  ],
+  "exclude": [
+    "node_modules/",
+    "dist/",
+    "src/**/*_test.ts",
+    "src/**/*_test_utils.ts",
+    "training/"
   ]
 }

--- a/speech-commands/tsconfig.json
+++ b/speech-commands/tsconfig.json
@@ -23,7 +23,6 @@
     "src/**/*"
   ],
   "exclude": [
-    "node_modules/",
     "dist/",
     "src/**/*_test.ts",
     "src/**/*_test_utils.ts",

--- a/speech-commands/yarn.lock
+++ b/speech-commands/yarn.lock
@@ -52,9 +52,9 @@
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.12.15":
-  version "0.12.15"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.15.tgz#b6c09dfe99cffd298745a694347b29a2c5aa9871"
+"@tensorflow/tfjs-core@0.12.17":
+  version "0.12.17"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.17.tgz#133fef53272e4dc0819890e79153c8ee094400b6"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"
@@ -65,12 +65,12 @@
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.5.tgz#54241110e0a6e194eafbbd18babca0978788e930"
 
-"@tensorflow/tfjs@0.12.6":
-  version "0.12.6"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.6.tgz#a77f62941e58aca097ac863b9dba22ed786322f5"
+"@tensorflow/tfjs@0.12.7":
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.7.tgz#2fb643f503dada14b7f0ca43d2a41082b626f92a"
   dependencies:
     "@tensorflow/tfjs-converter" "0.5.9"
-    "@tensorflow/tfjs-core" "0.12.15"
+    "@tensorflow/tfjs-core" "0.12.17"
     "@tensorflow/tfjs-layers" "0.7.5"
 
 "@types/estree@0.0.39":

--- a/speech-commands/yarn.lock
+++ b/speech-commands/yarn.lock
@@ -45,33 +45,33 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.5.7.tgz#b4b1a49cf90b5106a4351f1941c77c52f3f22ce9"
+"@tensorflow/tfjs-converter@0.5.9":
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.5.9.tgz#76913bd916bbd940b6435e9e3ec63f963c786b95"
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.12.11":
-  version "0.12.11"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.11.tgz#8da98fae720e58a484315d2e72d0c858991e4aee"
+"@tensorflow/tfjs-core@0.12.15":
+  version "0.12.15"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.12.15.tgz#b6c09dfe99cffd298745a694347b29a2c5aa9871"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"
     "@types/webgl2" "~0.0.4"
     seedrandom "~2.4.3"
 
-"@tensorflow/tfjs-layers@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.4.tgz#575a3bc2c895501c619b4b7102b4e17256c30835"
+"@tensorflow/tfjs-layers@0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.5.tgz#54241110e0a6e194eafbbd18babca0978788e930"
 
-"@tensorflow/tfjs@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.5.tgz#60d449457c99b661b4dce9e665e97f2476bc544c"
+"@tensorflow/tfjs@0.12.6":
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.6.tgz#a77f62941e58aca097ac863b9dba22ed786322f5"
   dependencies:
-    "@tensorflow/tfjs-converter" "0.5.7"
-    "@tensorflow/tfjs-core" "0.12.11"
-    "@tensorflow/tfjs-layers" "0.7.4"
+    "@tensorflow/tfjs-converter" "0.5.9"
+    "@tensorflow/tfjs-core" "0.12.15"
+    "@tensorflow/tfjs-layers" "0.7.5"
 
 "@types/estree@0.0.39":
   version "0.0.39"

--- a/speech-commands/yarn.lock
+++ b/speech-commands/yarn.lock
@@ -65,7 +65,7 @@
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.5.tgz#54241110e0a6e194eafbbd18babca0978788e930"
 
-"@tensorflow/tfjs@0.12.7":
+"@tensorflow/tfjs@^0.12.7":
   version "0.12.7"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.12.7.tgz#2fb643f503dada14b7f0ca43d2a41082b626f92a"
   dependencies:


### PR DESCRIPTION
Also in this PR:
* Add make-version script for automatic edits to version.ts
* Add unit test for exposed version string in the public API.
* In demo, increase the default number of training epochs for transfer learning from 20 to 40 (based on empirical observation of the transfer-learning accuracy)
* In the example in README.md, reflect the fact that @tensorflow/tfjs is a peer dependency.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/71)
<!-- Reviewable:end -->
