### PR TITLE
Fix coco-ssd package name and demo version

### DIFF
--- a/coco-ssd/demo/index.js
+++ b/coco-ssd/demo/index.js
@@ -15,8 +15,7 @@
  * =============================================================================
  */
 
-// TODO(ping): Switch to package import when the npm is published.
-import * as objectDetection from '../src';
+import * as cocoSsd from '@tensorflow-models/coco-ssd'
 
 import imageURL from './image1.jpg';
 import image2URL from './image2.jpg';
@@ -24,7 +23,7 @@ import image2URL from './image2.jpg';
 let modelPromise;
 let baseModel = 'lite_mobilenet_v2';
 
-window.onload = () => modelPromise = objectDetection.load();
+window.onload = () => modelPromise = cocoSsd.load();
 
 const button = document.getElementById('toggle');
 button.onclick = () => {
@@ -35,7 +34,7 @@ const select = document.getElementById('base_model');
 select.onchange = async (event) => {
   const model = await modelPromise;
   model.dispose();
-  modelPromise = objectDetection.load(
+  modelPromise = cocoSsd.load(
       event.srcElement.options[event.srcElement.selectedIndex].value);
 };
 

--- a/coco-ssd/demo/package.json
+++ b/coco-ssd/demo/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
       "@tensorflow/tfjs": "0.13.1",
-      "@tensorflow-models/coco-ssd": "0.0.1",
+      "@tensorflow-models/coco-ssd": "0.1.0",
       "stats.js": "^0.17.0"       
     },
     "scripts": {

--- a/coco-ssd/demo/yarn.lock
+++ b/coco-ssd/demo/yarn.lock
@@ -55,7 +55,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@tensorflow-models/coco-ssd@0.0.1":
+"@tensorflow-models/coco-ssd@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@tensorflow-models/coco-ssd/-/coco-ssd-0.1.0.tgz#b268df9ee28d1024c429a3306261a84aebbc18d2"
   integrity sha512-wp/yZAEkJiHCyl2fCgAdUB1J4+HNmn6lhXTZZbHlDXTr5ynBV2JutSMWcdt4spFcLwMAQBEJ7VQG2pQe753VnA==

--- a/coco-ssd/rollup.config.js
+++ b/coco-ssd/rollup.config.js
@@ -61,7 +61,7 @@ export default [
   config({
     output: {
       format: 'umd',
-      name: 'coco-ssd',
+      name: 'cocoSsd',
       file: 'dist/coco-ssd.js'
     }
   }),
@@ -69,7 +69,7 @@ export default [
     plugins: [minify()],
     output: {
       format: 'umd',
-      name: 'coco-ssd',
+      name: 'cocoSsd',
       file: 'dist/coco-ssd.min.js'
     }
   }),


### PR DESCRIPTION
Was trying out the coco-ssd model and found a few issues.

The output variable name in the rollup config file should be changed from coco-ssd to cocoSsd to both avoid dashes in variable names and also to match the readme sample usage (for script tag usage).

This PR also fixes the version listed for coco-ssd in the package.json and also switches the demo to import the npm package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/83)
<!-- Reviewable:end -->
