### PR TITLE
Add a README to the coco-ssd demo app

### DIFF
--- a/coco-ssd/README.md
+++ b/coco-ssd/README.md
@@ -67,7 +67,7 @@ You can also take a look at the [demo app](./demo).
 ## API
 
 #### Loading the model
-`object-detection` is the module name, which is automatically included when you use the `<script src>` method. When using ES6 imports, object-detection is the module.
+`coco-ssd` is the module name, which is automatically included when you use the `<script src>` method. When using ES6 imports, `coco-ssd` is the module.
 
 ```ts
 cocoSsd.load(
@@ -115,9 +115,9 @@ Returns an array of classes and probabilities that looks like:
 }]
 ```
 
-### Technical details for advance users
+### Technical details for advanced users
 
-This model is based on the TensorFlow object detection API, you can download the original models from [here](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md#coco-trained-models). We applied following optimizations to improve the performance for browser execution:
+This model is based on the TensorFlow object detection API. You can download the original models from [here](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md#coco-trained-models). We applied the following optimizations to improve the performance for browser execution:
 
   1. Removed the post process graph from the original model.
   2. Used single class NonMaxSuppression instead of original multiple classes NonMaxSuppression for faster speed with similar accuracy.

--- a/coco-ssd/demo/README.md
+++ b/coco-ssd/demo/README.md
@@ -1,0 +1,62 @@
+# Object Detection (COCO-SSD) Demo
+
+This demo allows you to try out object detection on a couple of preset images using different base models.
+
+## Setup
+
+`cd` into the demo/ folder:
+
+```sh
+cd coco-ssd/demo
+```
+
+Install dependencies:
+
+```sh
+yarn
+```
+
+Launch a development server, and watch files for changes. This command will also automatically open
+the demo app in your browser.
+
+```sh
+yarn watch
+```
+
+## If you are developing the model locally and want to test the changes in the demo
+
+`cd` into the coco-ssd/ folder:
+
+```sh
+cd coco-ssd
+```
+
+Install dependencies:
+```sh
+yarn
+```
+
+Publish coco-ssd locally:
+```sh
+yarn publish-local
+```
+
+`cd` into this directory (coco-ssd/demo) and install dependencies:
+
+```sh
+cd demo
+yarn
+```
+
+Link the package published from the publish step above:
+```sh
+yarn link-local
+```
+
+Start the dev demo server:
+```sh
+yarn watch
+```
+
+To get future updates from the `coco-ssd` source code, just run `yarn publish-local` in the coco-ssd/
+folder again.


### PR DESCRIPTION
This will help users know how to use and modify the coco-ssd demo app.

Old object-detection references were changed to coco-ssd in the main model README as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/84)
<!-- Reviewable:end -->
