### PR TITLE
fixed minor typo in POSENET output example

### DIFF
--- a/posenet/README.md
+++ b/posenet/README.md
@@ -464,7 +464,7 @@ This produces the output:
       }
     ],
   },
-  // pose 2
+  // pose 3
   {
     // pose score
     "score": 0.13461434583673,


### PR DESCRIPTION
Found a small typo in the example code of multiple poses outputs at the end of README.md. I believe it meant 'pose 3' , not 'pose 2'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/88)
<!-- Reviewable:end -->
