### PR TITLE
Added windows support for all demos

### DIFF
--- a/body-pix/demos/package.json
+++ b/body-pix/demos/package.json
@@ -14,8 +14,8 @@
     "stats.js": "0.17.0"
   },
   "scripts": {
-    "watch": "NODE_ENV=development parcel index.html --no-hmr --open ",
-    "build": "NODE_ENV=production parcel build index.html  --no-minify --public-url ./",
+    "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open ",
+    "build": "cross-env NODE_ENV=production parcel build index.html  --no-minify --public-url ./",
     "lint": "eslint ."
   },
   "devDependencies": {
@@ -24,6 +24,7 @@
     "babel-polyfill": "~6.26.0",
     "babel-preset-env": "~1.6.1",
     "clang-format": "~1.2.2",
+    "cross-env": "^5.2.0",
     "dat.gui": "~0.7.2",
     "eslint": "~4.19.1",
     "eslint-config-google": "~0.9.1",

--- a/coco-ssd/demo/package.json
+++ b/coco-ssd/demo/package.json
@@ -14,8 +14,8 @@
     "stats.js": "^0.17.0"
   },
   "scripts": {
-    "watch": "NODE_ENV=development parcel index.html --no-hmr --open",
-    "build": "NODE_ENV=production parcel build index.html  --no-minify --public-url ./",
+    "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open",
+    "build": "cross-env NODE_ENV=production parcel build index.html  --no-minify --public-url ./",
     "lint": "eslint .",
     "link-local": "yalc link @tensorflow-models/coco-ssd"
   },
@@ -27,6 +27,7 @@
     "babel-preset-es2017": "^6.24.1",
     "babel-runtime": "6.26.0",
     "clang-format": "~1.2.2",
+    "cross-env": "^5.2.0",
     "dat.gui": "^0.7.1",
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",

--- a/speech-commands/demo/package.json
+++ b/speech-commands/demo/package.json
@@ -13,8 +13,8 @@
     "stats.js": "^0.17.0"
   },
   "scripts": {
-    "watch": "NODE_ENV=development parcel index.html --no-hmr --open",
-    "build": "NODE_ENV=production parcel build index.html  --no-minify --public-url ./",
+    "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open",
+    "build": "cross-env NODE_ENV=production parcel build index.html  --no-minify --public-url ./",
     "lint": "eslint .",
     "link-local": "yalc link @tensorflow-models/speech-commands"
   },
@@ -25,6 +25,7 @@
     "babel-preset-env": "~1.6.1",
     "babel-preset-es2017": "^6.24.1",
     "clang-format": "~1.2.2",
+    "cross-env": "^5.2.0",
     "dat.gui": "^0.7.1",
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",


### PR DESCRIPTION
Without `cross-env NODE_ENV` was impossible to run the demos on windows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/112)
<!-- Reviewable:end -->
