### PR TITLE
[speech-commands] Support collecting longer recordings for transfer learning

### DIFF
--- a/speech-commands/demo/.babelrc
+++ b/speech-commands/demo/.babelrc
@@ -13,6 +13,6 @@
     ]
   ],
   "plugins": [
-    "transform-runtime"
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/speech-commands/demo/index.html
+++ b/speech-commands/demo/index.html
@@ -28,6 +28,18 @@
       border-color: #a0a0a0;
     }
 
+    select {
+      color: #ff8300;
+      background-color: #ffffff;
+      border-style: solid;
+      border-width: 2px;
+      border-color: #ff8300;
+      border-radius: 10px;
+      font-size: 20px;
+      margin: 5px;
+      padding: 15px;
+    }
+
     .transfer-learn-section input {
       color: #0000ff;
       background-color: #ffffff;
@@ -146,7 +158,12 @@
   </div>
   <div class="transfer-learn-section">
     <input id="learn-words" size="40" value="_background_noise_,red,green">
+    <select id="duration-multiplier">
+      <option value="1">Duration x1</option>
+      <option value="2">Duration x2</option>
+    </select>
     <button id="enter-learn-words" disabled="true">Enter transfer words</button>
+
 
     <div id="transfer-learn-history"></div>
     <div id="collect-words"></div>

--- a/speech-commands/demo/index.js
+++ b/speech-commands/demo/index.js
@@ -33,7 +33,7 @@ const downloadFilesButton = document.getElementById('download-dataset');
 const datasetFileInput = document.getElementById('dataset-file-input');
 const uploadFilesButton = document.getElementById('upload-dataset');
 
-const BACKGROUND_NOISE_TAG = '_background_noise_';
+const BACKGROUND_NOISE_TAG = SpeechCommands.BACKGROUND_NOISE_TAG;
 
 /**
  * Transfer learning-related UI componenets.

--- a/speech-commands/demo/index.js
+++ b/speech-commands/demo/index.js
@@ -151,22 +151,29 @@ function scrollToPageBottom() {
 async function addExample(wordDiv, word, spectrogram) {
   if (spectrogram == null) {
     // Collect an example online.
-    spectrogram = await transferRecognizer.collectExample(word);
+    spectrogram = await transferRecognizer.collectExample(word, {
+      durationMultiplier: 2
+    });
   }
 
   const exampleCanvas = document.createElement('canvas');
   exampleCanvas.style['display'] = 'inline-block';
   exampleCanvas.style['vertical-align'] = 'middle';
-  exampleCanvas.style['height'] = '60px';
-  exampleCanvas.style['width'] = '80px';
+  exampleCanvas.height = 60;
+  exampleCanvas.width = 80;
   exampleCanvas.style['padding'] = '3px';
   if (wordDiv.children.length > 1) {
     wordDiv.removeChild(wordDiv.children[wordDiv.children.length - 1]);
   }
   wordDiv.appendChild(exampleCanvas);
-  plotSpectrogram(
+
+  const modelNumFrames = recognizer.modelInputShape()[1];
+  await plotSpectrogram(
       exampleCanvas, spectrogram.data, spectrogram.frameSize,
-      spectrogram.frameSize);
+      spectrogram.frameSize, {
+        pixelsPerFrame: exampleCanvas.width / modelNumFrames,
+        markMaxIntensityFrame: true
+      });
 
   const button = wordDiv.children[0];
   const displayWord = word === BACKGROUND_NOISE_TAG ? 'noise' : word;

--- a/speech-commands/demo/index.js
+++ b/speech-commands/demo/index.js
@@ -47,7 +47,8 @@ const startTransferLearnButton =
 const XFER_MODEL_NAME = 'xfer-model';
 
 // Minimum required number of examples per class for transfer learning.
-const MIN_EXAPMLES_PER_CLASS = 8;
+// TODO(cais): Change back to 8. DO NOT SUBMIT.
+const MIN_EXAPMLES_PER_CLASS = 4;
 
 let recognizer;
 let transferRecognizer;

--- a/speech-commands/demo/package.json
+++ b/speech-commands/demo/package.json
@@ -19,8 +19,9 @@
     "link-local": "yalc link @tensorflow-models/speech-commands"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0-0",
+    "@babel/plugin-transform-runtime": "^7.1.0",
     "babel-core": "^6.26.3",
-    "babel-plugin-transform-runtime": "~6.23.0",
     "babel-polyfill": "~6.26.0",
     "babel-preset-env": "~1.6.1",
     "babel-preset-es2017": "^6.24.1",

--- a/speech-commands/demo/yarn.lock
+++ b/speech-commands/demo/yarn.lock
@@ -29,12 +29,43 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.0.0-0":
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.6.tgz#3733cbee4317429bc87c62b29cf8587dba7baeb3"
+  integrity sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.1.6"
+    "@babel/helpers" "^7.1.5"
+    "@babel/parser" "^7.1.6"
+    "@babel/template" "^7.1.2"
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.1.6"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.10"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0", "@babel/generator@^7.1.2", "@babel/generator@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.3.tgz#2103ec9c42d9bdad9190a6ad5ff2d456fd7b8673"
   integrity sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==
   dependencies:
     "@babel/types" "^7.1.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@^7.1.6":
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.6.tgz#001303cf87a5b9d093494a4bf251d7b5d03d3999"
+  integrity sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==
+  dependencies:
+    "@babel/types" "^7.1.6"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
@@ -212,6 +243,15 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.1.2"
 
+"@babel/helpers@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.1.5.tgz#68bfc1895d685f2b8f1995e788dbfe1f6ccb1996"
+  integrity sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==
+  dependencies:
+    "@babel/template" "^7.1.2"
+    "@babel/traverse" "^7.1.5"
+    "@babel/types" "^7.1.5"
+
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -225,6 +265,11 @@
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.3.tgz#2c92469bac2b7fbff810b67fca07bd138b48af77"
   integrity sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==
+
+"@babel/parser@^7.1.6":
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.6.tgz#16e97aca1ec1062324a01c5a6a7d0df8dd189854"
+  integrity sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==
 
 "@babel/plugin-proposal-async-generator-functions@^7.1.0":
   version "7.1.0"
@@ -496,6 +541,16 @@
   dependencies:
     regenerator-transform "^0.13.3"
 
+"@babel/plugin-transform-runtime@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz#9f76920d42551bb577e2dc594df229b5f7624b63"
+  integrity sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz#85f8af592dcc07647541a0350e8c95c7bf419d15"
@@ -620,10 +675,34 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
+"@babel/traverse@^7.1.5", "@babel/traverse@^7.1.6":
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.6.tgz#c8db9963ab4ce5b894222435482bd8ea854b7b5c"
+  integrity sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.1.6"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.1.6"
+    "@babel/types" "^7.1.6"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
 "@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.3.tgz#3a767004567060c2f40fca49a304712c525ee37d"
   integrity sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.1.5", "@babel/types@^7.1.6":
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.6.tgz#0adb330c3a281348a190263aceb540e10f04bcce"
+  integrity sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -1365,13 +1444,6 @@ babel-plugin-transform-regenerator@^6.22.0:
   integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=
   dependencies:
     regenerator-transform "^0.10.0"
-
-babel-plugin-transform-runtime@~6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  integrity sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=
-  dependencies:
-    babel-runtime "^6.22.0"
 
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
@@ -2391,6 +2463,13 @@ debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
   dependencies:
     ms "^2.1.1"
 
@@ -3777,6 +3856,13 @@ json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
+
+json5@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
 
@@ -5530,7 +5616,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.5, resolve@^1.1.6, resolve@^1.3.2, resolve@^1.4.0:
+resolve@^1.1.5, resolve@^1.1.6, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
@@ -5628,7 +5714,7 @@ seedrandom@2.4.3:
   resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
   integrity sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==

--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -19,12 +19,11 @@ import * as tf from '@tensorflow/tfjs';
 
 import {BrowserFftFeatureExtractor, SpectrogramCallback} from './browser_fft_extractor';
 import {loadMetadataJson, normalize} from './browser_fft_utils';
-import {Dataset} from './dataset';
+import {BACKGROUND_NOISE_TAG, Dataset} from './dataset';
 import {balancedTrainValSplit} from './training_utils';
 import {Example, RecognizeConfig, RecognizerCallback, RecognizerParams, SpectrogramData, SpeechCommandRecognizer, SpeechCommandRecognizerResult, StreamingRecognitionConfig, TransferLearnConfig, TransferSpeechCommandRecognizer, ExampleCollectionOptions} from './types';
 import {version} from './version';
 
-export const BACKGROUND_NOISE_TAG = '_background_noise_';
 export const UNKNOWN_TAG = '_unknown_';
 
 let streaming = false;

--- a/speech-commands/src/browser_fft_recognizer_test.ts
+++ b/speech-commands/src/browser_fft_recognizer_test.ts
@@ -1137,5 +1137,17 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
     expect(transfer2.countExamples()).toEqual({'bar': 1, 'foo': 1});
   });
 
+  fit('collectExample with durationMultiplier = 1.5', async () => {
+    setUpFakes();
+    const base = new BrowserFftSpeechCommandRecognizer();
+    await base.ensureModelLoaded();
+    const transfer = base.createTransfer('xfer1');
+    const spectrogram =
+        await transfer.collectExample('foo', {durationMultiplier: 1.5});
+    expect(spectrogram.frameSize).toEqual(fakeColumnTruncateLength);
+    const numFrames = spectrogram.data.length / fakeColumnTruncateLength;
+    expect(numFrames).toEqual(fakeNumFrames * 1.5);
+  });
+
   // TODO(cais): Add tests for saving and loading of transfer-learned models.
 });

--- a/speech-commands/src/browser_fft_recognizer_test.ts
+++ b/speech-commands/src/browser_fft_recognizer_test.ts
@@ -1137,7 +1137,7 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
     expect(transfer2.countExamples()).toEqual({'bar': 1, 'foo': 1});
   });
 
-  fit('collectExample with durationMultiplier = 1.5', async () => {
+  it('collectExample with durationMultiplier = 1.5', async () => {
     setUpFakes();
     const base = new BrowserFftSpeechCommandRecognizer();
     await base.ensureModelLoaded();

--- a/speech-commands/src/dataset.ts
+++ b/speech-commands/src/dataset.ts
@@ -324,11 +324,10 @@ export class Dataset {
           }
 
           const snippetLength = spectrogram.data.length / frameSize;
-          const maxIntensityFrame = currentLabel === BACKGROUND_NOISE_TAG ?
+          const focusIndex = currentLabel === BACKGROUND_NOISE_TAG ?
               null :
-              getMaxIntensityFrameIndex(spectrogram);
+              getMaxIntensityFrameIndex(spectrogram).dataSync()[0];
           // TODO(cais): See if we can get rid of dataSync();
-          const focusIndex = maxIntensityFrame.dataSync()[0];
 
           const windows =
               getValidWindows(snippetLength, focusIndex, numFrames, hopFrames);

--- a/speech-commands/src/dataset.ts
+++ b/speech-commands/src/dataset.ts
@@ -527,3 +527,26 @@ export function getValidWindows(
   }
   return windows;
 }
+
+/**
+ * TODO(cais): Doc string. DO NOT SUBMIT.
+ * @param spectrogram
+ * @returns
+ */
+export function spectrogram2IntensityCurve(spectrogram: SpectrogramData):
+    tf.Tensor {
+  return tf.tidy(() => {
+    const numFrames = spectrogram.data.length / spectrogram.frameSize;
+    const x = tf.tensor2d(spectrogram.data, [numFrames, spectrogram.frameSize]);
+    return x.mean(-1);
+  });
+}
+
+/**
+ * TODO(cais): Doc string. DO NOT SUBMIT.
+ * @param spectrogram
+ * @returns
+ */
+export function getMaxIntensityFrameIndex(spectrogram: SpectrogramData): tf.Scalar {
+  return tf.tidy(() => spectrogram2IntensityCurve(spectrogram).argMax());
+}

--- a/speech-commands/src/dataset.ts
+++ b/speech-commands/src/dataset.ts
@@ -562,14 +562,22 @@ export function arrayBuffer2SerializedExamples(buffer: ArrayBuffer):
 }
 
 /**
- * TODO(cais): Doc string. DO NOT SUBMIT.
+ * Get valid windows in a long snippet.
  *
- * TODO(cais): Unit tests. DO NOT SUBMIT.
- * @param snippetLength
+ * Each window is represented by an inclusive left index and an exclusive
+ * right index.
+ *
+ * @param snippetLength Long of the entire snippet. Must be a positive
+ *   integer.
  * @param focusIndex Optional. If `null` or `undefined`, an array of
  *   evenly-spaced windows will be generated. The array of windows will
  *   start from the first possible location (i.e., [0, windowLength]).
- * @param windowLength
+ *   If not `null` or `undefined`, must be an integer >= 0 and < snippetLength.
+ * @param windowLength Length of each window. Must be a positive integer and
+ *   <= snippetLength.
+ * @param windowHop Hops between successsive windows. Must be a positive
+ *   integer.
+ * @returns An array of [beginIndex, endIndex] pairs.
  */
 export function getValidWindows(
     snippetLength: number, focusIndex: number, windowLength: number,
@@ -641,9 +649,14 @@ export function getValidWindows(
 }
 
 /**
- * TODO(cais): Doc string. DO NOT SUBMIT.
- * @param spectrogram
- * @returns
+ * Calculate an intensity profile from a spectrogram.
+ *
+ * The intensity at each time frame is caclulated by simply averaging all the
+ * spectral values that belong to that time frame.
+ *
+ * @param spectrogram The input spectrogram.
+ * @returns The temporal profile of the intensity as a 1D tf.Tensor of shape
+ *   `[numFrames]`.
  */
 export function spectrogram2IntensityCurve(spectrogram: SpectrogramData):
     tf.Tensor {
@@ -655,9 +668,13 @@ export function spectrogram2IntensityCurve(spectrogram: SpectrogramData):
 }
 
 /**
- * TODO(cais): Doc string. DO NOT SUBMIT.
- * @param spectrogram
- * @returns
+ * Get the index to the maximum intensity frame.
+ *
+ * The intensity of each time frame is calculated as the arithmetic mean of
+ * all the spectral values belonging to that time frame.
+ *
+ * @param spectrogram The input spectrogram.
+ * @returns The index to the time frame containing the maximum intensity.
  */
 export function getMaxIntensityFrameIndex(spectrogram: SpectrogramData):
     tf.Scalar {

--- a/speech-commands/src/dataset.ts
+++ b/speech-commands/src/dataset.ts
@@ -412,8 +412,8 @@ export function deserializeExample(
   return ex;
 }
 
-/** 
- * Encode intermediate serialization format as an ArrayBuffer. 
+/**
+ * Encode intermediate serialization format as an ArrayBuffer.
  *
  * Format of the binary ArrayBuffer:
  *   1. An 8-byte descriptor (see above).
@@ -465,4 +465,65 @@ export function arrayBuffer2SerializedExamples(buffer: ArrayBuffer):
   const manifest = JSON.parse(manifestString);
   const data = buffer.slice(offset);
   return {manifest, data};
+}
+
+/**
+ * TODO(cais): Doc string. DO NOT SUBMIT.
+ *
+ * TODO(cais): Unit tests. DO NOT SUBMIT.
+ * @param snippetLength
+ * @param focusIndex
+ * @param windowLength
+ */
+export function getValidWindows(
+    snippetLength: number, focusIndex: number, windowLength: number,
+    windowHop: number): Array<[number, number]> {
+  tf.util.assert(
+      Number.isInteger(snippetLength) && snippetLength > 0,
+      `snippetLength must be a positive integer, but got ${snippetLength}`);
+  tf.util.assert(
+      Number.isInteger(focusIndex) && focusIndex >= 0,
+      `focusIndex must be a non-negative integer, but got ${focusIndex}`);
+  tf.util.assert(
+      Number.isInteger(windowLength) && windowLength > 0,
+      `windowLength must be a positive integer, but got ${windowLength}`);
+  tf.util.assert(
+      Number.isInteger(windowHop) && windowLength > 0,
+      `windowHop must be a positive integer, but got ${windowHop}`);
+  tf.util.assert(
+      windowLength <= snippetLength,
+      `windowLength (${windowLength}) exceeds snippetLength ` +
+          `(${snippetLength})`);
+  tf.util.assert(
+      focusIndex < snippetLength,
+      `focusIndex (${focusIndex}) equals or exceeds snippetLength ` +
+          `(${snippetLength})`);
+
+  if (windowLength == snippetLength) {
+    return [[0, snippetLength]];
+  }
+
+  const leftHalf = Math.floor(windowLength / 2);
+  let left = focusIndex - leftHalf;
+  if (left < 0) {
+    left = 0;
+  } else {
+    while (true) {
+      if (left - windowHop < 0 ||
+          focusIndex >= left - windowHop + windowLength) {
+        break;
+      }
+      left -= windowHop;
+    }
+  }
+
+  const windows: Array<[number, number]> = [];
+  while (left + windowLength <= snippetLength) {
+    if (focusIndex < left) {
+      break;
+    }
+    windows.push([left, left + windowLength]);
+    left += windowHop;
+  }
+  return windows;
 }

--- a/speech-commands/src/dataset.ts
+++ b/speech-commands/src/dataset.ts
@@ -245,7 +245,8 @@ export class Dataset {
    *     `Dataset`, or
    *   - if the `Dataset` is currently empty.
    */
-  getSpectrogramsAsTensors(label?: string):
+  getSpectrogramsAsTensors(
+      label?: string, config?: GetSepctrogramsAsTensorsConfig):
       {xs: tf.Tensor4D, ys?: tf.Tensor2D} {
     tf.util.assert(
         this.size() > 0,
@@ -265,28 +266,53 @@ export class Dataset {
               `at least two words, but it has only ${vocab.length} word.`);
     }
 
+    if (config == null) {
+      config = {};
+    }
+
+    // Get the numFrames lengths of all the examples currently held by the
+    // dataset.
+    const sortedUniqueNumFrames = this.getSortedUniqueNumFrames();
+    let numFrames: number;
+    let hopFrames: number;
+    if (sortedUniqueNumFrames.length === 1) {
+      numFrames = sortedUniqueNumFrames[0];
+      hopFrames = 1;
+    } else {
+      numFrames = config.numFrames;
+      tf.util.assert(
+          numFrames != null && Number.isInteger(numFrames) && numFrames > 0,
+          `There are ${sortedUniqueNumFrames.length} unique lengths among ` +
+              `the ${this.size()} examples of this Dataset, hence numFrames ` +
+              `is required. But it is not provided.`);
+      tf.util.assert(
+          numFrames <= sortedUniqueNumFrames[0],
+          `numFrames (${numFrames}) exceeds the minimum numFrames ` +
+              `(${sortedUniqueNumFrames[0]}) among the examples of ` +
+              `the Dataset.`);
+
+      hopFrames = config.hopFrames;
+      tf.util.assert(
+          hopFrames != null && Number.isInteger(hopFrames) && hopFrames > 0,
+          `There are ${sortedUniqueNumFrames.length} unique lengths among ` +
+              `the ${this.size()} examples of this Dataset, hence hopFrames ` +
+              `must be provided. But it is not provided.`);
+    }
+
     return tf.tidy(() => {
       const xTensors: tf.Tensor3D[] = [];
       const labelIndices: number[] = [];
-      let uniqueNumFrames: number;
+      // let uniqueNumFrames: number;  // TODO(cais): Remove.
       let uniqueFrameSize: number;
       for (let i = 0; i < vocab.length; ++i) {
         const currentLabel = vocab[i];
-        if (label != null && label !== currentLabel) {
+        if (label != null && currentLabel !== label) {
           continue;
         }
         const ids = this.label2Ids[currentLabel];
         for (const id of ids) {
           const spectrogram = this.examples[id].spectrogram;
           const frameSize = spectrogram.frameSize;
-          const numFrames = spectrogram.data.length / frameSize;
-          if (uniqueNumFrames == null) {
-            uniqueNumFrames = numFrames;
-          } else {
-            tf.util.assert(
-                numFrames === uniqueNumFrames,
-                `Mismatch in numFrames (${numFrames} vs ${uniqueNumFrames})`);
-          }
           if (uniqueFrameSize == null) {
             uniqueFrameSize = frameSize;
           } else {
@@ -295,10 +321,32 @@ export class Dataset {
                 `Mismatch in frameSize  ` +
                     `(${frameSize} vs ${uniqueFrameSize})`);
           }
-          xTensors.push(
-              tf.tensor3d(spectrogram.data, [numFrames, frameSize, 1]));
-          if (label == null) {
-            labelIndices.push(i);
+
+          const snippetLength = spectrogram.data.length / frameSize;
+          const maxIntensityFrame = currentLabel === BACKGROUND_NOISE_TAG ?
+              null :
+              getMaxIntensityFrameIndex(spectrogram);
+          // TODO(cais): See if we can get rid of dataSync();
+          const focusIndex = maxIntensityFrame.dataSync()[0];
+
+          console.log(
+              `spectrogram length = ${spectrogram.data.length}; ` +
+              `snippetLength = ${snippetLength}; ` +
+              `numFrames = ${numFrames}; ` +
+              `focusIndex = ${focusIndex}`);  // DEBUG
+          const windows =
+              getValidWindows(snippetLength, focusIndex, numFrames, hopFrames);
+          console.log(`Label = ${currentLabel}: windows = ${
+              JSON.stringify(windows)}`);  // DEBUG
+
+          const snippet =
+              tf.tensor3d(spectrogram.data, [snippetLength, frameSize, 1]);
+          for (const window of windows) {
+            xTensors.push(snippet.slice(
+                [window[0], 0, 0], [window[1] - window[0], -1, -1]));
+            if (label == null) {
+              labelIndices.push(i);
+            }
           }
         }
       }
@@ -310,6 +358,23 @@ export class Dataset {
             undefined
       };
     });
+  }
+
+  private getSortedUniqueNumFrames(): number[] {
+    const numFramesSet = new Set<number>();
+    const vocab = this.getVocabulary();
+    for (let i = 0; i < vocab.length; ++i) {
+      const label = vocab[i];
+      const ids = this.label2Ids[label];
+      for (const id of ids) {
+        const spectrogram = this.examples[id].spectrogram;
+        const numFrames = spectrogram.data.length / spectrogram.frameSize;
+        numFramesSet.add(numFrames);
+      }
+    }
+    const uniqueNumFrames = [...numFramesSet];
+    uniqueNumFrames.sort();
+    return uniqueNumFrames;
   }
 
   /**
@@ -560,14 +625,16 @@ export function getValidWindows(
   let left = focusIndex - leftHalf;
   if (left < 0) {
     left = 0;
-  } else {
-    while (true) {
-      if (left - windowHop < 0 ||
-          focusIndex >= left - windowHop + windowLength) {
-        break;
-      }
-      left -= windowHop;
+  } else if (left + windowLength > snippetLength) {
+    console.log('Adjusting...');  // DEBUG
+    left = snippetLength - windowLength;
+  }
+
+  while (true) {
+    if (left - windowHop < 0 || focusIndex >= left - windowHop + windowLength) {
+      break;
     }
+    left -= windowHop;
   }
 
   while (left + windowLength <= snippetLength) {
@@ -599,6 +666,7 @@ export function spectrogram2IntensityCurve(spectrogram: SpectrogramData):
  * @param spectrogram
  * @returns
  */
-export function getMaxIntensityFrameIndex(spectrogram: SpectrogramData): tf.Scalar {
+export function getMaxIntensityFrameIndex(spectrogram: SpectrogramData):
+    tf.Scalar {
   return tf.tidy(() => spectrogram2IntensityCurve(spectrogram).argMax());
 }

--- a/speech-commands/src/dataset.ts
+++ b/speech-commands/src/dataset.ts
@@ -499,7 +499,7 @@ export function getValidWindows(
       `focusIndex (${focusIndex}) equals or exceeds snippetLength ` +
           `(${snippetLength})`);
 
-  if (windowLength == snippetLength) {
+  if (windowLength === snippetLength) {
     return [[0, snippetLength]];
   }
 

--- a/speech-commands/src/dataset.ts
+++ b/speech-commands/src/dataset.ts
@@ -276,8 +276,9 @@ export class Dataset {
     let numFrames: number;
     let hopFrames: number;
     if (sortedUniqueNumFrames.length === 1) {
-      numFrames = sortedUniqueNumFrames[0];
-      hopFrames = 1;
+      numFrames = config.numFrames == null ? sortedUniqueNumFrames[0] :
+                                             config.numFrames;
+      hopFrames = config.hopFrames == null ? 1 : config.hopFrames;
     } else {
       numFrames = config.numFrames;
       tf.util.assert(
@@ -296,7 +297,7 @@ export class Dataset {
           hopFrames != null && Number.isInteger(hopFrames) && hopFrames > 0,
           `There are ${sortedUniqueNumFrames.length} unique lengths among ` +
               `the ${this.size()} examples of this Dataset, hence hopFrames ` +
-              `must be provided. But it is not provided.`);
+              `is required. But it is not provided.`);
     }
 
     return tf.tidy(() => {
@@ -333,6 +334,7 @@ export class Dataset {
               `spectrogram length = ${spectrogram.data.length}; ` +
               `snippetLength = ${snippetLength}; ` +
               `numFrames = ${numFrames}; ` +
+              `hopFrames = ${hopFrames}; ` +
               `focusIndex = ${focusIndex}`);  // DEBUG
           const windows =
               getValidWindows(snippetLength, focusIndex, numFrames, hopFrames);

--- a/speech-commands/src/dataset.ts
+++ b/speech-commands/src/dataset.ts
@@ -330,16 +330,8 @@ export class Dataset {
           // TODO(cais): See if we can get rid of dataSync();
           const focusIndex = maxIntensityFrame.dataSync()[0];
 
-          console.log(
-              `spectrogram length = ${spectrogram.data.length}; ` +
-              `snippetLength = ${snippetLength}; ` +
-              `numFrames = ${numFrames}; ` +
-              `hopFrames = ${hopFrames}; ` +
-              `focusIndex = ${focusIndex}`);  // DEBUG
           const windows =
               getValidWindows(snippetLength, focusIndex, numFrames, hopFrames);
-          console.log(`Label = ${currentLabel}: windows = ${
-              JSON.stringify(windows)}`);  // DEBUG
 
           const snippet =
               tf.tensor3d(spectrogram.data, [snippetLength, frameSize, 1]);
@@ -595,7 +587,7 @@ export function getValidWindows(
       Number.isInteger(windowLength) && windowLength > 0,
       `windowLength must be a positive integer, but got ${windowLength}`);
   tf.util.assert(
-      Number.isInteger(windowHop) && windowLength > 0,
+      Number.isInteger(windowHop) && windowHop > 0,
       `windowHop must be a positive integer, but got ${windowHop}`);
   tf.util.assert(
       windowLength <= snippetLength,
@@ -616,9 +608,10 @@ export function getValidWindows(
     // Deal with the special case of no focus frame:
     // Output an array of evenly-spaced windows, starting from
     // the first possible location.
-    const begin = 0;
+    let begin = 0;
     while (begin + windowLength <= snippetLength) {
       windows.push([begin, begin + windowLength]);
+      begin += windowHop;
     }
     return windows;
   }
@@ -628,7 +621,6 @@ export function getValidWindows(
   if (left < 0) {
     left = 0;
   } else if (left + windowLength > snippetLength) {
-    console.log('Adjusting...');  // DEBUG
     left = snippetLength - windowLength;
   }
 

--- a/speech-commands/src/dataset_test.ts
+++ b/speech-commands/src/dataset_test.ts
@@ -515,7 +515,7 @@ describe('Dataset serialization', () => {
 });
 
 describe('getValidWindows', () => {
-  fit('Left and right sides open, odd windowLength', () => {
+  it('Left and right sides open, odd windowLength', () => {
     const snippetLength = 100;
     const focusIndex = 50;
     const windowLength = 21;
@@ -525,7 +525,7 @@ describe('getValidWindows', () => {
     expect(windows).toEqual([[30, 51], [35, 56], [40, 61], [45, 66], [50, 71]]);
   });
 
-  fit('Left and right sides open, even windowLength', () => {
+  it('Left and right sides open, even windowLength', () => {
     const snippetLength = 100;
     const focusIndex = 50;
     const windowLength = 20;
@@ -535,7 +535,7 @@ describe('getValidWindows', () => {
     expect(windows).toEqual([[35, 55], [40, 60], [45, 65], [50, 70]]);
   });
 
-  fit('Left side truncation, right side open', () => {
+  it('Left side truncation, right side open', () => {
     const snippetLength = 100;
     const focusIndex = 8;
     const windowLength = 20;
@@ -545,7 +545,7 @@ describe('getValidWindows', () => {
     expect(windows).toEqual([[0, 20], [5, 25]]);
   });
 
-  fit('Left side truncation extreme, right side open', () => {
+  it('Left side truncation extreme, right side open', () => {
     const snippetLength = 100;
     const focusIndex = 0;
     const windowLength = 21;
@@ -555,7 +555,7 @@ describe('getValidWindows', () => {
     expect(windows).toEqual([[0, 21]]);
   });
 
-  fit('Right side truncation, left side open', () => {
+  it('Right side truncation, left side open', () => {
     const snippetLength = 100;
     const focusIndex = 95;
     const windowLength = 20;
@@ -565,7 +565,7 @@ describe('getValidWindows', () => {
     expect(windows).toEqual([[80, 100]]);
   });
 
-  fit('Right side truncation extreme, left side open', () => {
+  it('Right side truncation extreme, left side open', () => {
     const snippetLength = 100;
     const focusIndex = 99;
     const windowLength = 21;
@@ -575,7 +575,7 @@ describe('getValidWindows', () => {
     expect(windows).toEqual([[79, 100]]);
   });
 
-  fit('Neither side has enough room for another hop 1', () => {
+  it('Neither side has enough room for another hop 1', () => {
     const snippetLength = 100;
     const focusIndex = 50;
     const windowLength = 21;
@@ -585,7 +585,7 @@ describe('getValidWindows', () => {
     expect(windows).toEqual([[40, 61]]);
   });
 
-  fit('Neither side has enough room for another hop 2', () => {
+  it('Neither side has enough room for another hop 2', () => {
     const snippetLength = 100;
     const focusIndex = 50;
     const windowLength = 91;
@@ -595,7 +595,7 @@ describe('getValidWindows', () => {
     expect(windows).toEqual([[5, 96]]);
   });
 
-  fit('Exact match', () => {
+  it('Exact match', () => {
     const snippetLength = 10;
     const windowLength = 10;
     const windowHop = 2;
@@ -617,7 +617,7 @@ describe('getValidWindows', () => {
         .toEqual([[0, 10]]);
   });
 
-  fit('Almost exact match', () => {
+  it('Almost exact match', () => {
     const snippetLength = 12;
     const windowLength = 10;
     const windowHop = 2;
@@ -639,7 +639,7 @@ describe('getValidWindows', () => {
         .toEqual([[0, 10], [2, 12]]);
   });
 
-  fit('Non-positive integer snippetLength values lead to errors', () => {
+  it('Non-positive integer snippetLength values lead to errors', () => {
     const windowLength = 10;
     const focusIndex = 5;
     const windowHop = 2;
@@ -660,7 +660,7 @@ describe('getValidWindows', () => {
         .toThrow();
   });
 
-  fit('Non-positive integer windowLength values lead to errors', () => {
+  it('Non-positive integer windowLength values lead to errors', () => {
     const snippetLength = 10;
     const focusIndex = 5;
     const windowHop = 2;
@@ -681,7 +681,7 @@ describe('getValidWindows', () => {
         .toThrow();
   });
 
-  fit('Negative or non-integer focusIndex values lead to errors', () => {
+  it('Negative or non-integer focusIndex values lead to errors', () => {
     const snippetLength = 10;
     const windowLength = 10;
     const windowHop = 2;
@@ -697,7 +697,7 @@ describe('getValidWindows', () => {
         .toThrow();
   });
 
-  fit('Out-of-bound focusIndex leads to error', () => {
+  it('Out-of-bound focusIndex leads to error', () => {
     const snippetLength = 10;
     const windowLength = 10;
     const windowHop = 2;
@@ -713,7 +713,7 @@ describe('getValidWindows', () => {
         .toThrow();
   });
 
-  fit('Out-of-bound windowLength leads to error', () => {
+  it('Out-of-bound windowLength leads to error', () => {
     const snippetLength = 10;
     const windowLength = 12;
     const windowHop = 2;

--- a/speech-commands/src/dataset_test.ts
+++ b/speech-commands/src/dataset_test.ts
@@ -747,4 +747,14 @@ describe('getMaxIntensityFrameIndex', () => {
     const maxIntensityFrameIndex = getMaxIntensityFrameIndex(spectrogram);
     expectArraysClose(maxIntensityFrameIndex, tf.scalar(3, 'int32'));
   });
+
+  it('Only one frames', () => {
+    const x = tf.tensor2d([[11, 12]]);
+    const spectrogram: SpectrogramData = {
+      data: x.dataSync() as Float32Array,
+      frameSize: 2
+    };
+    const maxIntensityFrameIndex = getMaxIntensityFrameIndex(spectrogram);
+    expectArraysClose(maxIntensityFrameIndex, tf.scalar(0, 'int32'));
+  });
 });

--- a/speech-commands/src/dataset_test.ts
+++ b/speech-commands/src/dataset_test.ts
@@ -757,4 +757,22 @@ describe('getMaxIntensityFrameIndex', () => {
     const maxIntensityFrameIndex = getMaxIntensityFrameIndex(spectrogram);
     expectArraysClose(maxIntensityFrameIndex, tf.scalar(0, 'int32'));
   });
+
+  it('No focus frame: return multiple windows', () => {
+    const snippetLength = 100;
+    const windowLength = 40;
+    const windowHop = 20;
+    const windows =
+        getValidWindows(snippetLength, null, windowLength, windowHop);
+    expect(windows).toEqual([[0, 40],  [20, 60], [40, 80], [60, 100]]);
+  });
+
+  it('No focus frame: return one window', () => {
+    const snippetLength = 10;
+    const windowLength = 10;
+    const windowHop = 2;
+    const windows =
+        getValidWindows(snippetLength, null, windowLength, windowHop);
+    expect(windows).toEqual([[0, 10]]);
+  });
 });

--- a/speech-commands/src/dataset_test.ts
+++ b/speech-commands/src/dataset_test.ts
@@ -725,7 +725,7 @@ describe('getValidWindows', () => {
   });
 });
 
-describe('spectrogram2IntensityCurvev', () => {
+describe('spectrogram2IntensityCurve', () => {
   it('Correctness', () => {
     const x = tf.tensor2d([[1, 2], [3, 4], [5, 6]]);
     const spectrogram: SpectrogramData = {

--- a/speech-commands/src/dataset_test.ts
+++ b/speech-commands/src/dataset_test.ts
@@ -330,7 +330,7 @@ describe('Dataset', () => {
         .toThrowError(/Cannot get spectrograms as tensors because.*empty/);
   });
 
-  fit('Ragged example lengths and one window per example', () => {
+  it('Ragged example lengths and one window per example', () => {
     const dataset = new Dataset();
     dataset.addExample(getRandomExample('foo', 5));
     dataset.addExample(getRandomExample('bar', 6));
@@ -342,7 +342,19 @@ describe('Dataset', () => {
     expectArraysClose(ys, tf.tensor2d([[1, 0], [0, 1], [0, 1]]));
   });
 
-  fit('Ragged example lengths and multiple windows per example', () => {
+  it('Ragged example lengths and one window per example, with label', () => {
+    const dataset = new Dataset();
+    dataset.addExample(getRandomExample('foo', 5));
+    dataset.addExample(getRandomExample('bar', 6));
+    dataset.addExample(getRandomExample('foo', 7));
+
+    const {xs, ys} =
+        dataset.getSpectrogramsAsTensors('foo', {numFrames: 5, hopFrames: 5});
+    expect(xs.shape).toEqual([2, 5, FAKE_FRAME_SIZE, 1]);
+    expect(ys).toBeUndefined();
+  });
+
+  it('Ragged example lengths and multiple windows per example', () => {
     const dataset = new Dataset();
     dataset.addExample(getRandomExample(
         'foo', 6, 2, [10, 10, 20, 20, 30, 30, 20, 20, 10, 10, 0, 0]));
@@ -367,7 +379,7 @@ describe('Dataset', () => {
         ys, tf.tensor2d([[1, 0], [1, 0], [1, 0], [0, 1], [0, 1], [0, 1]]));
   });
 
-  fit('Uniform example lengths and multiple windows per example', () => {
+  it('Uniform example lengths and multiple windows per example', () => {
     const dataset = new Dataset();
     dataset.addExample(getRandomExample(
         'foo', 6, 2, [10, 10, 20, 20, 30, 30, 20, 20, 10, 10, 0, 0]));
@@ -391,7 +403,7 @@ describe('Dataset', () => {
     expectArraysClose(ys, tf.tensor2d([[1, 0], [1, 0], [0, 1], [0, 1]]));
   });
 
-  fit('numFrames exceeding minmum example length leads to Error', () => {
+  it('numFrames exceeding minmum example length leads to Error', () => {
     const dataset = new Dataset();
     dataset.addExample(getRandomExample(
         'foo', 6, 2, [10, 10, 20, 20, 30, 30, 20, 20, 10, 10, 0, 0]));
@@ -403,7 +415,7 @@ describe('Dataset', () => {
     })).toThrowError(/.*6.*exceeds the minimum numFrames .*5.*/);
   });
 
-  fit('Ragged examples with no numFrames leads to Error', () => {
+  it('Ragged examples with no numFrames leads to Error', () => {
     const dataset = new Dataset();
     dataset.addExample(getRandomExample(
         'foo', 6, 2, [10, 10, 20, 20, 30, 30, 20, 20, 10, 10, 0, 0]));
@@ -413,7 +425,7 @@ describe('Dataset', () => {
         .toThrowError(/numFrames is required/);
   });
 
-  fit('Ragged examples with no hopFrames leads to Error', () => {
+  it('Ragged examples with no hopFrames leads to Error', () => {
     const dataset = new Dataset();
     dataset.addExample(getRandomExample(
         'foo', 6, 2, [10, 10, 20, 20, 30, 30, 20, 20, 10, 10, 0, 0]));
@@ -611,7 +623,7 @@ describe('Dataset serialization', () => {
   });
 });
 
-fdescribe('getValidWindows', () => {
+describe('getValidWindows', () => {
   it('Left and right sides open, odd windowLength', () => {
     const snippetLength = 100;
     const focusIndex = 50;

--- a/speech-commands/src/index.ts
+++ b/speech-commands/src/index.ts
@@ -69,7 +69,7 @@ export function create(
   }
 }
 
-export {Dataset, getMaxIntensityFrameIndex, spectrogram2IntensityCurve} from './dataset';
+export {BACKGROUND_NOISE_TAG, Dataset, GetSepctrogramsAsTensorsConfig, getMaxIntensityFrameIndex, spectrogram2IntensityCurve} from './dataset';
 export {Example, FFT_TYPE, RecognizerParams, SpectrogramData, SpeechCommandRecognizerResult, StreamingRecognitionConfig, TransferLearnConfig} from './types';
-export {BACKGROUND_NOISE_TAG, UNKNOWN_TAG} from './browser_fft_recognizer';
+export {UNKNOWN_TAG} from './browser_fft_recognizer';
 export {version} from './version';

--- a/speech-commands/src/index.ts
+++ b/speech-commands/src/index.ts
@@ -69,7 +69,7 @@ export function create(
   }
 }
 
-export {Dataset} from './dataset';
+export {Dataset, getMaxIntensityFrameIndex, spectrogram2IntensityCurve} from './dataset';
 export {Example, FFT_TYPE, RecognizerParams, SpectrogramData, SpeechCommandRecognizerResult, StreamingRecognitionConfig, TransferLearnConfig} from './types';
 export {BACKGROUND_NOISE_TAG, UNKNOWN_TAG} from './browser_fft_recognizer';
 export {version} from './version';

--- a/speech-commands/src/types.ts
+++ b/speech-commands/src/types.ts
@@ -401,6 +401,20 @@ export interface TransferLearnConfig {
    * and is a positive integer.
    */
   fineTuningCallback?: tf.CustomCallbackConfig;
+
+  /**
+   * Ratio between the window hop and the window width.
+   *
+   * Used during extraction of multiple spectrograms matching the underlying
+   * model's input shape from a longer spectroram.
+   *
+   * Defaults to 0.25.
+   *
+   * For example, if the spectrogram window accepted by the underlying model
+   * is 43 frames long, then the default windowHopRatio 0.25 will lead to
+   * a hop of Math.round(43 * 0.25) = 11 frames.
+   */
+  windowHopRatio?: number;
 }
 
 /**

--- a/speech-commands/src/types.ts
+++ b/speech-commands/src/types.ts
@@ -114,6 +114,21 @@ export interface SpeechCommandRecognizer {
   createTransfer(name: string): TransferSpeechCommandRecognizer;
 }
 
+export interface ExampleCollectionOptions {
+  /**
+   * Multiplier for the duration.
+   *
+   * This is the ratio between the duration of the to-be-collected
+   * example and the duration of each input example accepted by the
+   * underlying convnet.
+   *
+   * If not provided, will default to 1.
+   *
+   * Must be a number >=1.
+   */
+  durationMultiplier?: number;
+}
+
 /**
  * Interface for a transfer-learning speech command recognizer.
  *
@@ -133,7 +148,8 @@ export interface TransferSpeechCommandRecognizer extends
    * @throws Error, if word belongs to the set of words the base model is
    *   trained to recognize.
    */
-  collectExample(word: string): Promise<SpectrogramData>;
+  collectExample(word: string, options?: ExampleCollectionOptions):
+      Promise<SpectrogramData>;
 
   /**
    * Clear all transfer learning examples collected so far.


### PR DESCRIPTION
Rationale: 
- Longer recordings allow temporal jitters, which is a form of data augmentation that has been shown to benefit online-recognition accuracy in empirical tests

API level changes:
- `collectExample()` now has a new config parameters: `durationMultiplier`, which if set to a value >1, will let the method collect a spectrogram longer than that required by the underlying TensorFlow.js model.

