### PR TITLE
[speech-commands] Fix a flaky test and a wrong console message

### DIFF
--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -917,12 +917,12 @@ class TransferBrowserFftSpeechCommandRecognizer extends
     const datasetDurationMillisThreshold =
         config.fitDatasetDurationMillisThreshold == null ?
         60e3 : config.fitDatasetDurationMillisThreshold;
-    console.log(
-        `Detected large dataset: total duration = ` +
-        `${this.dataset.durationMillis()} ms > ` +
-        `${datasetDurationMillisThreshold} ms. ` +
-        `Training transfer model using fitDataset() instead of fit()`);
     if (this.dataset.durationMillis() > datasetDurationMillisThreshold) {
+      console.log(
+          `Detected large dataset: total duration = ` +
+          `${this.dataset.durationMillis()} ms > ` +
+          `${datasetDurationMillisThreshold} ms. ` +
+          `Training transfer model using fitDataset() instead of fit()`);
       return await this.trainOnDataset(config);
     } else {
       return await this.trainOnTensors(config);


### PR DESCRIPTION
- Fixes https://github.com/tensorflow/tfjs/issues/1192
  The previous assumption was that the kernel of the dense
  layer gets updated. But sometimes, the bias updates and
  the kernel doesn't.
- A console.log message regarding large datasets and the use
  of fitDataset() was placed in the wrong place. This PR fixes
  that as well.