### PR TITLE
missing command in demo readme

### DIFF
--- a/posenet/demos/README.md
+++ b/posenet/demos/README.md
@@ -55,7 +55,7 @@ yarn
 
 Publish posenet locally:
 ```sh
-yalc push
+yarn build && yalc push
 ```
 
 Cd into the demos and install dependencies:


### PR DESCRIPTION
If you try to run the current instructions on a fresh clone, `yarn watch` will fail. Adding a `yarn build` command fixes things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/146)
<!-- Reviewable:end -->
