### PR TITLE
Update bodypix to depend on tfjs 0.15.1

### DIFF
--- a/body-pix/demos/README.md
+++ b/body-pix/demos/README.md
@@ -41,9 +41,9 @@ Install dependencies:
 yarn
 ```
 
-Publish body-pix locally:
+Build and publish the body-pix locally:
 ```sh
-yalc push
+yarn publish-local
 ```
 
 Cd into the demos and install dependencies:

--- a/body-pix/demos/index.html
+++ b/body-pix/demos/index.html
@@ -70,6 +70,7 @@
    <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
    rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
 </head>
 
 <body>

--- a/body-pix/demos/package.json
+++ b/body-pix/demos/package.json
@@ -9,8 +9,8 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow-models/body-pix": "0.0.1",
-    "@tensorflow/tfjs": "0.15.0",
+    "@tensorflow-models/body-pix": "0.1.1",
+    "@tensorflow/tfjs": "0.15.1",
     "stats.js": "0.17.0"
   },
   "scripts": {

--- a/body-pix/demos/yarn.lock
+++ b/body-pix/demos/yarn.lock
@@ -695,53 +695,53 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@tensorflow-models/body-pix@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow-models/body-pix/-/body-pix-0.0.1.tgz#4a5520bd0b59ed77822e8818c24b41d50d8dc9e5"
-  integrity sha512-nh4SqnsThTpcImQni6FqwKTqaHIqp0SH+7siLvwOorGggw5lI4W7yZ1HCWsWZFTpeXAsesBx1W3epaZTcDX5PQ==
+"@tensorflow-models/body-pix@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow-models/body-pix/-/body-pix-0.1.1.tgz#35c111684c639adc936c61dc3d785b6b29dc4f32"
+  integrity sha512-pdbzyDjDJCwdE95MiZ7hAsBSpVlNmDbeHNWygEwv4pozcVG8nA/a9r2jlD6k2Vx57ne0DA+q0ifvrQ9+sVqTVA==
 
-"@tensorflow/tfjs-converter@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.8.0.tgz#d6c07a64ca376d7d4f4f57623e9ba35d074ca2d5"
-  integrity sha512-OcraKdqO6M6vPgzcexER0cLXTsy7dM3URvko90Z6Vv9blP36BKZXRQYwqm91J0FbuLDrFJZ3uKubUVsIMbKAMQ==
+"@tensorflow/tfjs-converter@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.8.1.tgz#baecc2dd20e5fca81391df1c6f11a7e865c71ce9"
+  integrity sha512-tdUq5N6y+L9XUM6c9poAP9GAAkzh9XEtP/mD96nFxllpNeDODSmDkdZKFzoAkmXwubojcUSJ1wbVYqCFbgaCOg==
   dependencies:
     "@types/long" "~3.0.32"
     js-base64 "2.4.9"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.0.tgz#c85f1141e42ce5103ae73fdf170b2d4736038533"
-  integrity sha512-YITCsLeF8lqFQdepdv+a0wRQ4sVtg31cvqRzsuQBeQHyR04Xb3CH0kgKcwTj8FUXn+IlDsjE7m+v8Gier7YfuA==
+"@tensorflow/tfjs-core@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.1.tgz#6196d2a9630236c77d71e036f05d2d6eadc2a25a"
+  integrity sha512-csZ1GvRiwy0PJcJXz6Xt9W+ZZHf0JI+nyJPtJU4QSVJVIFRCCAWqn2SsYwNt2Bp2rw2ZHhfuStz3veFUgaDSMA==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-data@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-0.2.0.tgz#c66c73e634b56f46c7a17db0af6c3be8b9cc4428"
-  integrity sha512-ut7TpdJE8I1YoaROKGs/AwZXa9d8GqOeBd/l2JFLQwzLVhA9LLh0fzCdIBnUGa6Gp5MdwD+3OoysV+neMDAs2w==
+"@tensorflow/tfjs-data@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-0.2.1.tgz#6a4b2e08ef472b6f1a533b07c59aff71c2f4d03f"
+  integrity sha512-A8YSCtPkaXXQeJwI7CUw/Y+vCoCxiCRIH4Z0DOTD16dl9Iz4S+sr8VA3I4HsLLgS9BNXbRWFQxnbCe/j1ATtuA==
   dependencies:
     "@types/node-fetch" "^2.1.2"
     node-fetch "~2.1.2"
     seedrandom "~2.4.3"
 
-"@tensorflow/tfjs-layers@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.10.0.tgz#a282ad3f533ac20645b23b0eaf5d15039ec91b5d"
-  integrity sha512-O24iUscjutLFjRmJj55FASXtssD2Tldkz6n+MJ64gN0Etq+zA9A+Sbz3pWIjvDaKDhcXHsy4kmSbENF9Cztqqw==
+"@tensorflow/tfjs-layers@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.10.1.tgz#b7019302b776c7281fde425043659b6e97403dfb"
+  integrity sha512-p8b6mynBR/owKCRKR7J0tu7Qherlyzsm5MkgfVk9Z1PCqsR79soYEf1VbPsRap5g09Xl8RZgB5S/aMkRHy18Qg==
 
-"@tensorflow/tfjs@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.15.0.tgz#bd8d7c109f25ba06c5686deca79bb0fff93507bc"
-  integrity sha512-MP8N8vptlL1sTxH1K8m64SE+8Kw6FBmGtRMOY8R/AVEWW4Z1DD+crsMHUePzxXwU83HHeZPXJauKyzX/U1CgCQ==
+"@tensorflow/tfjs@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.15.1.tgz#ed3ae264159eb60e63be38edb83fdb6cd03db2d2"
+  integrity sha512-PV+Heq+YrGp14e3+brYcC7SZVtq7wsrxyJe6YQIwySMcGBipP2i6UCWJMgbq8W71MMGBrST+dSBUkM1QZkZpHw==
   dependencies:
-    "@tensorflow/tfjs-converter" "0.8.0"
-    "@tensorflow/tfjs-core" "0.15.0"
-    "@tensorflow/tfjs-data" "0.2.0"
-    "@tensorflow/tfjs-layers" "0.10.0"
+    "@tensorflow/tfjs-converter" "0.8.1"
+    "@tensorflow/tfjs-core" "0.15.1"
+    "@tensorflow/tfjs-data" "0.2.1"
+    "@tensorflow/tfjs-layers" "0.10.1"
 
 "@types/long@^4.0.0":
   version "4.0.0"

--- a/body-pix/package.json
+++ b/body-pix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/body-pix",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pretrained BodyPix model in TensorFlow.js",
   "main": "dist/index.js",
   "jsnext:main": "dist/body-pix.esm.js",
@@ -13,10 +13,10 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs": "^0.15.0"
+    "@tensorflow/tfjs": "^0.15.1"
   },
   "devDependencies": {
-    "@tensorflow/tfjs": "^0.15.0",
+    "@tensorflow/tfjs": "^0.15.1",
     "@types/jasmine": "~2.5.53",
     "jasmine": "~3.2.0",
     "jasmine-core": "~3.1.0",
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc",
-    "publish-local": "yarn build && yalc push",
+    "publish-local": "yarn build && rollup -c && yalc push",
     "test": "ts-node run_tests.ts",
     "publish-npm": "yarn build && rollup -c && npm publish",
     "lint": "tslint -p . -t verbose"

--- a/body-pix/src/util.ts
+++ b/body-pix/src/util.ts
@@ -9,7 +9,7 @@ export function getInputTensorDimensions(input: BodyPixInput):
 }
 
 export function toInputTensor(input: BodyPixInput) {
-  return input instanceof tf.Tensor ? input : tf.fromPixels(input);
+  return input instanceof tf.Tensor ? input : tf.browser.fromPixels(input);
 }
 
 export function resizeAndPadTo(

--- a/body-pix/yarn.lock
+++ b/body-pix/yarn.lock
@@ -55,48 +55,48 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@tensorflow/tfjs-converter@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.8.0.tgz#d6c07a64ca376d7d4f4f57623e9ba35d074ca2d5"
-  integrity sha512-OcraKdqO6M6vPgzcexER0cLXTsy7dM3URvko90Z6Vv9blP36BKZXRQYwqm91J0FbuLDrFJZ3uKubUVsIMbKAMQ==
+"@tensorflow/tfjs-converter@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.8.1.tgz#baecc2dd20e5fca81391df1c6f11a7e865c71ce9"
+  integrity sha512-tdUq5N6y+L9XUM6c9poAP9GAAkzh9XEtP/mD96nFxllpNeDODSmDkdZKFzoAkmXwubojcUSJ1wbVYqCFbgaCOg==
   dependencies:
     "@types/long" "~3.0.32"
     js-base64 "2.4.9"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.0.tgz#c85f1141e42ce5103ae73fdf170b2d4736038533"
-  integrity sha512-YITCsLeF8lqFQdepdv+a0wRQ4sVtg31cvqRzsuQBeQHyR04Xb3CH0kgKcwTj8FUXn+IlDsjE7m+v8Gier7YfuA==
+"@tensorflow/tfjs-core@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.15.1.tgz#6196d2a9630236c77d71e036f05d2d6eadc2a25a"
+  integrity sha512-csZ1GvRiwy0PJcJXz6Xt9W+ZZHf0JI+nyJPtJU4QSVJVIFRCCAWqn2SsYwNt2Bp2rw2ZHhfuStz3veFUgaDSMA==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-data@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-0.2.0.tgz#c66c73e634b56f46c7a17db0af6c3be8b9cc4428"
-  integrity sha512-ut7TpdJE8I1YoaROKGs/AwZXa9d8GqOeBd/l2JFLQwzLVhA9LLh0fzCdIBnUGa6Gp5MdwD+3OoysV+neMDAs2w==
+"@tensorflow/tfjs-data@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-0.2.1.tgz#6a4b2e08ef472b6f1a533b07c59aff71c2f4d03f"
+  integrity sha512-A8YSCtPkaXXQeJwI7CUw/Y+vCoCxiCRIH4Z0DOTD16dl9Iz4S+sr8VA3I4HsLLgS9BNXbRWFQxnbCe/j1ATtuA==
   dependencies:
     "@types/node-fetch" "^2.1.2"
     node-fetch "~2.1.2"
     seedrandom "~2.4.3"
 
-"@tensorflow/tfjs-layers@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.10.0.tgz#a282ad3f533ac20645b23b0eaf5d15039ec91b5d"
-  integrity sha512-O24iUscjutLFjRmJj55FASXtssD2Tldkz6n+MJ64gN0Etq+zA9A+Sbz3pWIjvDaKDhcXHsy4kmSbENF9Cztqqw==
+"@tensorflow/tfjs-layers@0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.10.1.tgz#b7019302b776c7281fde425043659b6e97403dfb"
+  integrity sha512-p8b6mynBR/owKCRKR7J0tu7Qherlyzsm5MkgfVk9Z1PCqsR79soYEf1VbPsRap5g09Xl8RZgB5S/aMkRHy18Qg==
 
-"@tensorflow/tfjs@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.15.0.tgz#bd8d7c109f25ba06c5686deca79bb0fff93507bc"
-  integrity sha512-MP8N8vptlL1sTxH1K8m64SE+8Kw6FBmGtRMOY8R/AVEWW4Z1DD+crsMHUePzxXwU83HHeZPXJauKyzX/U1CgCQ==
+"@tensorflow/tfjs@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.15.1.tgz#ed3ae264159eb60e63be38edb83fdb6cd03db2d2"
+  integrity sha512-PV+Heq+YrGp14e3+brYcC7SZVtq7wsrxyJe6YQIwySMcGBipP2i6UCWJMgbq8W71MMGBrST+dSBUkM1QZkZpHw==
   dependencies:
-    "@tensorflow/tfjs-converter" "0.8.0"
-    "@tensorflow/tfjs-core" "0.15.0"
-    "@tensorflow/tfjs-data" "0.2.0"
-    "@tensorflow/tfjs-layers" "0.10.0"
+    "@tensorflow/tfjs-converter" "0.8.1"
+    "@tensorflow/tfjs-core" "0.15.1"
+    "@tensorflow/tfjs-data" "0.2.1"
+    "@tensorflow/tfjs-layers" "0.10.1"
 
 "@types/estree@0.0.38":
   version "0.0.38"


### PR DESCRIPTION
- Update bodypix to depend on tfjs 0.15.1
- Fix deprecated API usage
- Update body pix to 0.1.1 and release 0.1.1
- Update demo and upload on GCS: https://storage.googleapis.com/tfjs-models/demos/body-pix/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/147)
<!-- Reviewable:end -->
