### PR TITLE
Fix a parcel build warning; Bump version to 0.2.5

### DIFF
--- a/speech-commands/package.json
+++ b/speech-commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/speech-commands",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Speech-command recognizer in TensorFlow.js",
   "main": "dist/index.js",
   "unpkg": "dist/speech-commands.min.js",

--- a/speech-commands/src/browser_fft_utils.ts
+++ b/speech-commands/src/browser_fft_utils.ts
@@ -27,16 +27,12 @@ export async function loadMetadataJson(url: string):
       fetch(url).then(response => {
         response.json().then(parsed => resolve(parsed));
       });
-      // return await (await fetch(url)).json();
     } else if (url.indexOf(FILE_SCHEME) === 0) {
       // tslint:disable-next-line:no-require-imports
       const fs = require('fs');
       fs.readFile(
           url.slice(FILE_SCHEME.length), {encoding: 'utf-8'},
           (err: Error, data: string) => resolve(JSON.parse(data)));
-      // const content = JSON.parse(
-      //     fs.readFileSync();
-      // return content;
     } else {
       reject(new Error(
           `Unsupported URL scheme in metadata URL: ${url}. ` +

--- a/speech-commands/src/browser_fft_utils.ts
+++ b/speech-commands/src/browser_fft_utils.ts
@@ -39,7 +39,7 @@ export async function loadMetadataJson(url: string):
           `Supported schemes are: http://, https://, and ` +
           `(node.js-only) file://`));
     }
-  });
+  }) as Promise<{words: string[]}>;
 }
 
 let EPSILON: number = null;

--- a/speech-commands/src/browser_fft_utils.ts
+++ b/speech-commands/src/browser_fft_utils.ts
@@ -19,23 +19,31 @@ import * as tf from '@tensorflow/tfjs';
 
 export async function loadMetadataJson(url: string):
     Promise<{words: string[]}> {
-  const HTTP_SCHEME = 'http://';
-  const HTTPS_SCHEME = 'https://';
-  const FILE_SCHEME = 'file://';
-  if (url.indexOf(HTTP_SCHEME) === 0 || url.indexOf(HTTPS_SCHEME) === 0) {
-    return await (await fetch(url)).json();
-  } else if (url.indexOf(FILE_SCHEME) === 0) {
-    // tslint:disable-next-line:no-require-imports
-    const fs = require('fs');
-    const content = JSON.parse(
-        fs.readFileSync(url.slice(FILE_SCHEME.length), {encoding: 'utf-8'}));
-    return content;
-  } else {
-    throw new Error(
-        `Unsupported URL scheme in metadata URL: ${url}. ` +
-        `Supported schemes are: http://, https://, and ` +
-        `(node.js-only) file://`);
-  }
+  return new Promise((resolve, reject) => {
+    const HTTP_SCHEME = 'http://';
+    const HTTPS_SCHEME = 'https://';
+    const FILE_SCHEME = 'file://';
+    if (url.indexOf(HTTP_SCHEME) === 0 || url.indexOf(HTTPS_SCHEME) === 0) {
+      fetch(url).then(response => {
+        response.json().then(parsed => resolve(parsed));
+      });
+      // return await (await fetch(url)).json();
+    } else if (url.indexOf(FILE_SCHEME) === 0) {
+      // tslint:disable-next-line:no-require-imports
+      const fs = require('fs');
+      fs.readFile(
+          url.slice(FILE_SCHEME.length), {encoding: 'utf-8'},
+          (err: Error, data: string) => resolve(JSON.parse(data)));
+      // const content = JSON.parse(
+      //     fs.readFileSync();
+      // return content;
+    } else {
+      reject(new Error(
+          `Unsupported URL scheme in metadata URL: ${url}. ` +
+          `Supported schemes are: http://, https://, and ` +
+          `(node.js-only) file://`));
+    }
+  });
 }
 
 let EPSILON: number = null;

--- a/speech-commands/src/version.ts
+++ b/speech-commands/src/version.ts
@@ -1,4 +1,4 @@
 /** @license See the LICENSE file. */
 // This code is auto-generated, do not modify this file!
-const version = '0.2.4';
+const version = '0.2.5';
 export {version};


### PR DESCRIPTION
The parcel issue is described at:
https://github.com/parcel-bundler/parcel/issues/2363

parcel doesn't like `fs.readFileSync`. This PR uses `fs.readFile` to work around that.

BUG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/149)
<!-- Reviewable:end -->
