### PR TITLE
slightly tidier code imho

### DIFF
--- a/posenet/src/multi_pose/build_part_with_score_queue.ts
+++ b/posenet/src/multi_pose/build_part_with_score_queue.ts
@@ -24,12 +24,13 @@ function scoreIsMaximumInLocalWindow(
     localMaximumRadius: number, scores: TensorBuffer3D): boolean {
   const [height, width] = scores.shape;
 
-  let localMaximum = true;
+  const xStart = Math.max(heatmapX - localMaximumRadius, 0);
+  const xEnd = Math.min(heatmapX + localMaximumRadius + 1, width);
   const yStart = Math.max(heatmapY - localMaximumRadius, 0);
   const yEnd = Math.min(heatmapY + localMaximumRadius + 1, height);
+
+  let localMaximum = true;
   for (let yCurrent = yStart; yCurrent < yEnd; ++yCurrent) {
-    const xStart = Math.max(heatmapX - localMaximumRadius, 0);
-    const xEnd = Math.min(heatmapX + localMaximumRadius + 1, width);
     for (let xCurrent = xStart; xCurrent < xEnd; ++xCurrent) {
       if (scores.get(yCurrent, xCurrent, keypointId) > score) {
         localMaximum = false;


### PR DESCRIPTION
Reading through this code, I was briefly confused why `xStart` and `xEnd` are repeatedly reset inside the loop, since they don't depend on `yCurrent`.

Anyway this change could save someone else a a few brain cycles, and a few cpu cycles while we're at it 🤷‍♂️