### PR TITLE
[speech-commands] Support rolling spectrogram update during collectEx…

### DIFF
--- a/speech-commands/demo/index.js
+++ b/speech-commands/demo/index.js
@@ -265,7 +265,7 @@ function createWordDivs(transferWords) {
         wordDiv.appendChild(tempCanvas);
 
         collectExampleOptions.snippetDurationSec = 0.1;
-        collectExampleOptions.snippetCallback = async (spectrogram) => {
+        collectExampleOptions.onSnippet = async (spectrogram) => {
           if (tempSpectrogramData == null) {
             tempSpectrogramData = spectrogram.data;
           } else {

--- a/speech-commands/demo/index.js
+++ b/speech-commands/demo/index.js
@@ -258,29 +258,23 @@ function createWordDivs(transferWords) {
         // multiplier is >1 (> ~1 s recoding), show an incrementally
         // updating spectrogram in real time.
         collectExampleOptions.durationMultiplier = transferDurationMultiplier;
-        if (transferDurationMultiplier > 1) {
-          let tempSpectrogramData;
-          const tempCanvas = document.createElement('canvas');
-          tempCanvas.style['margin-left'] = '132px';
-          tempCanvas.height = 50;
-          wordDiv.appendChild(tempCanvas);
+        let tempSpectrogramData;
+        const tempCanvas = document.createElement('canvas');
+        tempCanvas.style['margin-left'] = '132px';
+        tempCanvas.height = 50;
+        wordDiv.appendChild(tempCanvas);
 
-          collectExampleOptions.snippetDurationSec = 0.1;
-          collectExampleOptions.snippetCallback = async (spectrogram) => {
-            if (tempSpectrogramData == null) {
-              tempSpectrogramData = spectrogram.data;
-            } else {
-              tempSpectrogramData = SpeechCommands.utils.concatenateFloat32Arrays(
-                  [tempSpectrogramData, spectrogram.data]);
-            }
-            plotSpectrogram(
-                tempCanvas, tempSpectrogramData, spectrogram.frameSize,
-                spectrogram.frameSize, {pixelsPerFrame: 2});
+        collectExampleOptions.snippetDurationSec = 0.1;
+        collectExampleOptions.snippetCallback = async (spectrogram) => {
+          if (tempSpectrogramData == null) {
+            tempSpectrogramData = spectrogram.data;
+          } else {
+            tempSpectrogramData = SpeechCommands.utils.concatenateFloat32Arrays(
+                [tempSpectrogramData, spectrogram.data]);
           }
-        } else {
-          const barAndJob = createProgressBarAndIntervalJob(wordDiv, 1);
-          progressBar = barAndJob.progressBar;
-          intervalJob = barAndJob.intervalJob;
+          plotSpectrogram(
+              tempCanvas, tempSpectrogramData, spectrogram.frameSize,
+              spectrogram.frameSize, {pixelsPerFrame: 2});
         }
       }
 

--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -736,7 +736,7 @@ class TransferBrowserFftSpeechCommandRecognizer extends
             });
           }
 
-          if (++callbackCount === callbackCountTarget) {
+          if (callbackCount++ === callbackCountTarget) {
             await this.audioDataExtractor.stop();
             streaming = false;
             this.collateTransferWords();

--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -671,15 +671,15 @@ class TransferBrowserFftSpeechCommandRecognizer extends
 
     if (options.snippetDurationSec != null) {
       tf.util.assert(options.snippetDurationSec > 0,
-          () => `snipppetDuration is expected to be > 0, but got ` +
+          () => `snippetDurationSec is expected to be > 0, but got ` +
               `${options.snippetDurationSec}`);
       tf.util.assert(options.snippetCallback != null,
-          () => `snippetCallback must be supplied if snippetDuration ` +
+          () => `snippetCallback must be provided if snippetDurationSec ` +
               `is provided.`);
     }
     if (options.snippetCallback != null) {
       tf.util.assert(options.snippetDurationSec != null,
-          () => `snippetDurationSec must be supplied if snippetCallback ` +
+          () => `snippetDurationSec must be provided if snippetCallback ` +
               `is provided.`);
     }
     const frameDurationSec =

--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -17,8 +17,9 @@
 
 import * as tf from '@tensorflow/tfjs';
 import {BrowserFftFeatureExtractor, SpectrogramCallback} from './browser_fft_extractor';
-import {loadMetadataJson, normalize} from './browser_fft_utils';
+import {loadMetadataJson, normalize, normalizeFloat32Array} from './browser_fft_utils';
 import {BACKGROUND_NOISE_TAG, Dataset} from './dataset';
+import {concatenateFloat32Arrays} from './generic_utils';
 import {balancedTrainValSplit} from './training_utils';
 import {EvaluateConfig, EvaluateResult, Example, ExampleCollectionOptions, RecognizeConfig, RecognizerCallback, RecognizerParams, ROCCurve, SpectrogramData, SpeechCommandRecognizer, SpeechCommandRecognizerMetadata, SpeechCommandRecognizerResult, StreamingRecognitionConfig, TransferLearnConfig, TransferSpeechCommandRecognizer} from './types';
 import {version} from './version';
@@ -668,25 +669,92 @@ class TransferBrowserFftSpeechCommandRecognizer extends
       numFramesPerSpectrogram = this.nonBatchInputShape[0];
     }
 
+    if (options.snippetDurationSec != null) {
+      tf.util.assert(options.snippetDurationSec > 0,
+          () => `snipppetDuration is expected to be > 0, but got ` +
+              `${options.snippetDurationSec}`);
+      tf.util.assert(options.snippetCallback != null,
+          () => `snippetCallback must be supplied if snippetDuration ` +
+              `is provided.`);
+    }
+    if (options.snippetCallback != null) {
+      tf.util.assert(options.snippetDurationSec != null, 
+          () => `snippetDurationSec must be supplied if snippetCallback ` +
+              `is provided.`);
+    }
+    const frameDurationSec =
+        this.parameters.fftSize / this.parameters.sampleRateHz;
+    const totalDurationSec = frameDurationSec * numFramesPerSpectrogram;
+
     streaming = true;
     return new Promise<SpectrogramData>(resolve => {
+      const stepFactor = options.snippetDurationSec == null ? 
+          1 : options.snippetDurationSec / totalDurationSec;
+      const overlapFactor = 1 - stepFactor;
+      const callbackCountTarget = Math.round(1 / stepFactor);
+      let callbackCount = 0;
+      let lastIndex = -1;
+      const spectrogramSnippets: Float32Array[] = [];
+
       const spectrogramCallback: SpectrogramCallback = async (x: tf.Tensor) => {
-        const normalizedX = normalize(x);
-        this.dataset.addExample({
-          label: word,
-          spectrogram: {
-            data: await normalizedX.data() as Float32Array,
+        // TODO(cais): can we consolidate the logic in the two branches?
+        if (options.snippetCallback == null) {
+          const normalizedX = normalize(x);
+          this.dataset.addExample({
+            label: word,
+            spectrogram: {
+              data: await normalizedX.data() as Float32Array,
+              frameSize: this.nonBatchInputShape[1],
+            }
+          });
+          normalizedX.dispose();
+          await this.audioDataExtractor.stop();
+          streaming = false;
+          this.collateTransferWords();
+          resolve({
+            data: await x.data() as Float32Array,
             frameSize: this.nonBatchInputShape[1],
+          });
+        } else {
+          const data = await x.data() as Float32Array;
+          if (lastIndex === -1) {
+            lastIndex = data.length;
           }
-        });
-        normalizedX.dispose();
-        await this.audioDataExtractor.stop();
-        streaming = false;
-        this.collateTransferWords();
-        resolve({
-          data: await x.data() as Float32Array,
-          frameSize: this.nonBatchInputShape[1],
-        });
+          let i = lastIndex - 1;
+          while (data[i] !== 0 && i >= 0) {
+            i--;
+          }
+          const increment = lastIndex - i - 1;
+          lastIndex = i + 1;
+          const snippetData = data.slice(data.length - increment, data.length);
+          spectrogramSnippets.push(snippetData);
+
+          if (options.snippetCallback != null) {
+            options.snippetCallback({
+              data: snippetData,
+              frameSize: this.nonBatchInputShape[1]
+            });
+          }
+
+          if (++callbackCount === callbackCountTarget) {
+            await this.audioDataExtractor.stop();
+            streaming = false;
+            this.collateTransferWords();
+
+            const normalized = normalizeFloat32Array(
+                concatenateFloat32Arrays(spectrogramSnippets));
+            const finalSpectrogram: SpectrogramData = {
+              data: normalized,
+              frameSize: this.nonBatchInputShape[1]
+            };
+            this.dataset.addExample({
+              label: word,
+              spectrogram: finalSpectrogram
+            });
+            // TODO(cais): Fix 1-tensor memory leak.
+            resolve(finalSpectrogram);
+          }
+        }
         return false;
       };
       this.audioDataExtractor = new BrowserFftFeatureExtractor({

--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -678,7 +678,7 @@ class TransferBrowserFftSpeechCommandRecognizer extends
               `is provided.`);
     }
     if (options.snippetCallback != null) {
-      tf.util.assert(options.snippetDurationSec != null, 
+      tf.util.assert(options.snippetDurationSec != null,
           () => `snippetDurationSec must be supplied if snippetCallback ` +
               `is provided.`);
     }
@@ -688,7 +688,7 @@ class TransferBrowserFftSpeechCommandRecognizer extends
 
     streaming = true;
     return new Promise<SpectrogramData>(resolve => {
-      const stepFactor = options.snippetDurationSec == null ? 
+      const stepFactor = options.snippetDurationSec == null ?
           1 : options.snippetDurationSec / totalDurationSec;
       const overlapFactor = 1 - stepFactor;
       const callbackCountTarget = Math.round(1 / stepFactor);
@@ -763,7 +763,7 @@ class TransferBrowserFftSpeechCommandRecognizer extends
         columnTruncateLength: this.nonBatchInputShape[1],
         suppressionTimeMillis: 0,
         spectrogramCallback,
-        overlapFactor: 0
+        overlapFactor
       });
       this.audioDataExtractor.start();
     });

--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -673,13 +673,13 @@ class TransferBrowserFftSpeechCommandRecognizer extends
       tf.util.assert(options.snippetDurationSec > 0,
           () => `snippetDurationSec is expected to be > 0, but got ` +
               `${options.snippetDurationSec}`);
-      tf.util.assert(options.snippetCallback != null,
-          () => `snippetCallback must be provided if snippetDurationSec ` +
+      tf.util.assert(options.onSnippet != null,
+          () => `onSnippet must be provided if snippetDurationSec ` +
               `is provided.`);
     }
-    if (options.snippetCallback != null) {
+    if (options.onSnippet != null) {
       tf.util.assert(options.snippetDurationSec != null,
-          () => `snippetDurationSec must be provided if snippetCallback ` +
+          () => `snippetDurationSec must be provided if onSnippet ` +
               `is provided.`);
     }
     const frameDurationSec =
@@ -698,7 +698,7 @@ class TransferBrowserFftSpeechCommandRecognizer extends
 
       const spectrogramCallback: SpectrogramCallback = async (x: tf.Tensor) => {
         // TODO(cais): can we consolidate the logic in the two branches?
-        if (options.snippetCallback == null) {
+        if (options.onSnippet == null) {
           const normalizedX = normalize(x);
           this.dataset.addExample({
             label: word,
@@ -729,8 +729,8 @@ class TransferBrowserFftSpeechCommandRecognizer extends
           const snippetData = data.slice(data.length - increment, data.length);
           spectrogramSnippets.push(snippetData);
 
-          if (options.snippetCallback != null) {
-            options.snippetCallback({
+          if (options.onSnippet != null) {
+            options.onSnippet({
               data: snippetData,
               frameSize: this.nonBatchInputShape[1]
             });

--- a/speech-commands/src/browser_fft_recognizer_test.ts
+++ b/speech-commands/src/browser_fft_recognizer_test.ts
@@ -653,6 +653,31 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
     }
   });
 
+  it('collectExample with snippetCallback', async () => {
+    setUpFakes();
+    const base = new BrowserFftSpeechCommandRecognizer();
+    await base.ensureModelLoaded();
+    const transfer = base.createTransfer('xfer1');
+    const durationSec = 1;
+    const snippetDurationSec = 0.1;
+    const snippetLengths: number[] = [];
+    const finalSpectrogram = await transfer.collectExample('foo', {
+      durationSec,
+      snippetDurationSec,
+      snippetCallback: async spectrogram => {
+        snippetLengths.push(spectrogram.data.length);
+      }
+    });
+    expect(snippetLengths.length).toEqual(10);
+    expect(snippetLengths[0]).toEqual(927);
+    for (let i = 1; i < snippetLengths.length; ++i) {
+      expect(snippetLengths[i]).toEqual(928);
+    }
+    expect(finalSpectrogram.data.length)
+       .toEqual(snippetLengths.reduce((prev, x) => x + prev));
+    console.log(finalSpectrogram.data.length);
+  });
+
   it('collectTransferLearningExample default transfer model', async () => {
     setUpFakes();
     const base = new BrowserFftSpeechCommandRecognizer();

--- a/speech-commands/src/browser_fft_recognizer_test.ts
+++ b/speech-commands/src/browser_fft_recognizer_test.ts
@@ -653,7 +653,7 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
     }
   });
 
-  it('collectExample with snippetCallback', async () => {
+  it('collectExample with onSnippet', async () => {
     setUpFakes();
     const base = new BrowserFftSpeechCommandRecognizer();
     await base.ensureModelLoaded();
@@ -664,7 +664,7 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
     const finalSpectrogram = await transfer.collectExample('foo', {
       durationSec,
       snippetDurationSec,
-      snippetCallback: async spectrogram => {
+      onSnippet: async spectrogram => {
         snippetLengths.push(spectrogram.data.length);
       }
     });
@@ -698,7 +698,7 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
     }
   });
 
-  it('collectExample w/ snippetCallback w/o snippetDurationSec error',
+  it('collectExample w/ onSnippet w/o snippetDurationSec error',
       async done => {
         setUpFakes();
         const base = new BrowserFftSpeechCommandRecognizer();
@@ -708,12 +708,12 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
         try {
           await transfer.collectExample('foo', {
             durationSec,
-            snippetCallback: async spectrogram => {}
+            onSnippet: async spectrogram => {}
           });
           done.fail();
         } catch (error) {
           expect(error.message).toMatch(
-              /snippetDurationSec must be provided if snippetCallback/);
+              /snippetDurationSec must be provided if onSnippet/);
           done();
         }
       });
@@ -734,7 +734,7 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
           done.fail();
         } catch (error) {
           expect(error.message).toMatch(
-              /snippetCallback must be provided if snippetDurationSec/);
+              /onSnippet must be provided if snippetDurationSec/);
           done();
         }
       });

--- a/speech-commands/src/browser_fft_recognizer_test.ts
+++ b/speech-commands/src/browser_fft_recognizer_test.ts
@@ -668,13 +668,15 @@ describeWithFlags('Browser FFT recognizer', tf.test_util.NODE_ENVS, () => {
         snippetLengths.push(spectrogram.data.length);
       }
     });
-    expect(snippetLengths.length).toEqual(10);
+    expect(snippetLengths.length).toEqual(11);
     expect(snippetLengths[0]).toEqual(927);
+    // First audio sample is zero and should have been skipped.
     for (let i = 1; i < snippetLengths.length; ++i) {
       expect(snippetLengths[i]).toEqual(928);
     }
     expect(finalSpectrogram.data.length)
        .toEqual(snippetLengths.reduce((x, prev) => x + prev));
+    expect(finalSpectrogram.data.length).toEqual(10208 - 1);
   });
 
   it('collectExample w/ invalid durationSec leads to error',  async done => {

--- a/speech-commands/src/browser_fft_utils.ts
+++ b/speech-commands/src/browser_fft_utils.ts
@@ -66,13 +66,17 @@ export function normalize(x: tf.Tensor): tf.Tensor {
 
 /**
  * Z-Normalize the elements of a Float32Array.
- * 
+ *
  * Subtract the mean and divide the result by the standard deviation.
- * 
+ *
  * @param x The Float32Array to normalize.
  * @return Noramlzied Float32Array.
  */
 export function normalizeFloat32Array(x: Float32Array): Float32Array {
+  if (x.length < 2) {
+    throw new Error(
+        'Cannot normalize a Float32Array with fewer than 2 elements.');
+  }
   if (EPSILON == null) {
     EPSILON = tf.ENV.get('EPSILON');
   }

--- a/speech-commands/src/browser_fft_utils.ts
+++ b/speech-commands/src/browser_fft_utils.ts
@@ -64,6 +64,28 @@ export function normalize(x: tf.Tensor): tf.Tensor {
   });
 }
 
+/**
+ * Z-Normalize the elements of a Float32Array.
+ * 
+ * Subtract the mean and divide the result by the standard deviation.
+ * 
+ * @param x The Float32Array to normalize.
+ * @return Noramlzied Float32Array.
+ */
+export function normalizeFloat32Array(x: Float32Array): Float32Array {
+  if (EPSILON == null) {
+    EPSILON = tf.ENV.get('EPSILON');
+  }
+  return tf.tidy(() => {
+    const {mean, variance} = tf.moments(tf.tensor1d(x));
+    const meanVal = mean.arraySync() as number;
+    const stdVal = Math.sqrt(variance.arraySync() as number);
+    const yArray = Array.from(x).map(
+        y => (y - meanVal) / (stdVal + EPSILON));
+    return new Float32Array(yArray);
+  });
+}
+
 export function getAudioContextConstructor(): AudioContext {
   // tslint:disable-next-line:no-any
   return (window as any).AudioContext || (window as any).webkitAudioContext;

--- a/speech-commands/src/browser_fft_utils_test.ts
+++ b/speech-commands/src/browser_fft_utils_test.ts
@@ -45,7 +45,10 @@ describe('normalize', () => {
 describe('normalizeFloat32Array', () => {
   it('Length-4 input', () => {
     const xs = new Float32Array([1, 2, 3, 4]);
+    const numTensors0 = tf.memory().numTensors;
     const ys = normalizeFloat32Array(xs);
+    // Assert no memory leak.
+    expect(tf.memory().numTensors).toEqual(numTensors0);
     test_util.expectArraysClose(
         ys, new Float32Array([-1.3416406, -0.4472135, 0.4472135, 1.3416406]));
   });

--- a/speech-commands/src/browser_fft_utils_test.ts
+++ b/speech-commands/src/browser_fft_utils_test.ts
@@ -17,7 +17,7 @@
 
 import * as tf from '@tensorflow/tfjs';
 import {test_util} from '@tensorflow/tfjs';
-import {normalize} from './browser_fft_utils';
+import {normalize, normalizeFloat32Array} from './browser_fft_utils';
 
 describe('normalize', () => {
   it('Non-constant value; no memory leak', () => {
@@ -39,5 +39,14 @@ describe('normalize', () => {
     const x = tf.tensor4d([42, 42, 42, 42], [1, 2, 2, 1]);
     const y = normalize(x);
     test_util.expectArraysClose(y, tf.tensor4d([0, 0, 0, 0], [1, 2, 2, 1]));
+  });
+});
+
+describe('normalizeFloat32Array', () => {
+  it('Length-4 input', () => {
+    const xs = new Float32Array([1, 2, 3, 4]);
+    const ys = normalizeFloat32Array(xs);
+    test_util.expectArraysClose(
+        ys, new Float32Array([-1.3416406, -0.4472135, 0.4472135, 1.3416406]));
   });
 });

--- a/speech-commands/src/generic_utils.ts
+++ b/speech-commands/src/generic_utils.ts
@@ -36,6 +36,25 @@ export function concatenateArrayBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
   return temp.buffer;
 }
 
+/**
+ * Concatenate Float32Arrays.
+ *
+ * @param xs Float32Arrays to concatenate.
+ * @return The result of the concatenation.
+ */
+export function concatenateFloat32Arrays(xs: Float32Array[]): Float32Array {
+  // TODO(cais): Add unit test.
+  let totalLength = 0;
+  xs.forEach(x => totalLength += x.length);
+  const concatenated = new Float32Array(totalLength);
+  let index = 0;
+  xs.forEach(x => {
+    concatenated.set(x, index);
+    index += x.length;
+  });
+  return concatenated;
+}
+
 /** Encode a string as an ArrayBuffer. */
 export function string2ArrayBuffer(str: string): ArrayBuffer {
   if (str == null) {

--- a/speech-commands/src/generic_utils.ts
+++ b/speech-commands/src/generic_utils.ts
@@ -43,7 +43,6 @@ export function concatenateArrayBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
  * @return The result of the concatenation.
  */
 export function concatenateFloat32Arrays(xs: Float32Array[]): Float32Array {
-  // TODO(cais): Add unit test.
   let totalLength = 0;
   xs.forEach(x => totalLength += x.length);
   const concatenated = new Float32Array(totalLength);

--- a/speech-commands/src/generic_utils_test.ts
+++ b/speech-commands/src/generic_utils_test.ts
@@ -16,7 +16,8 @@
  * =============================================================================
  */
 
-import {arrayBuffer2String, string2ArrayBuffer} from './generic_utils';
+import {arrayBuffer2String, string2ArrayBuffer, concatenateFloat32Arrays} from './generic_utils';
+import {expectArraysEqual} from '@tensorflow/tfjs-core/dist/test_util';
 
 describe('string2ArrayBuffer and arrayBuffer2String', () => {
   it('round trip: ASCII only', () => {
@@ -30,5 +31,51 @@ describe('string2ArrayBuffer and arrayBuffer2String', () => {
   it('round trip: empty string', () => {
     const str = '';
     expect(arrayBuffer2String(string2ArrayBuffer(str))).toEqual(str);
+  });
+});
+
+describe('concatenateFloat32Arrays', () => {
+  it('Two non-empty', () => {
+    const xs = new Float32Array([1, 3]);
+    const ys = new Float32Array([3, 7]);
+    expectArraysEqual(concatenateFloat32Arrays([xs, ys]),
+        new Float32Array([1, 3, 3, 7]));
+    expectArraysEqual(concatenateFloat32Arrays([ys, xs]),
+        new Float32Array([3, 7, 1, 3]));
+    // Assert that the original Float32Arrays are not altered.
+    expectArraysEqual(xs, new Float32Array([1, 3]));
+    expectArraysEqual(ys, new Float32Array([3, 7]));
+  });
+
+  it('Three unequal lengths non-empty', () => {
+    const array1 = new Float32Array([1]);
+    const array2 = new Float32Array([2, 3]);
+    const array3 = new Float32Array([4, 5, 6]);
+    expectArraysEqual(concatenateFloat32Arrays([array1, array2, array3]),
+        new Float32Array([1, 2, 3, 4, 5, 6]));
+  });
+
+  it('One empty, one non-empty', () => {
+    const xs = new Float32Array([4, 2]);
+    const ys = new Float32Array(0);
+    expectArraysEqual(concatenateFloat32Arrays([xs, ys]),
+        new Float32Array([4, 2]));
+    expectArraysEqual(concatenateFloat32Arrays([ys, xs]),
+        new Float32Array([4, 2]));
+    // Assert that the original Float32Arrays are not altered.
+    expectArraysEqual(xs, new Float32Array([4, 2]));
+    expectArraysEqual(ys, new Float32Array(0));
+  });
+
+  it('Two empty', () => {
+    const xs = new Float32Array(0);
+    const ys = new Float32Array(0);
+    expectArraysEqual(concatenateFloat32Arrays([xs, ys]),
+        new Float32Array(0));
+    expectArraysEqual(concatenateFloat32Arrays([ys, xs]),
+        new Float32Array(0));
+    // Assert that the original Float32Arrays are not altered.
+    expectArraysEqual(xs, new Float32Array(0));
+    expectArraysEqual(ys, new Float32Array(0));
   });
 });

--- a/speech-commands/src/index.ts
+++ b/speech-commands/src/index.ts
@@ -18,6 +18,7 @@
 import * as tf from '@tensorflow/tfjs';
 
 import {BrowserFftSpeechCommandRecognizer} from './browser_fft_recognizer';
+import {concatenateFloat32Arrays} from './generic_utils';
 import {FFT_TYPE, SpeechCommandRecognizer} from './types';
 
 /**
@@ -70,7 +71,10 @@ export function create(
   }
 }
 
+const utils = {concatenateFloat32Arrays};
+
 export {BACKGROUND_NOISE_TAG, Dataset, GetDataConfig as GetSpectrogramsAsTensorsConfig, getMaxIntensityFrameIndex, spectrogram2IntensityCurve, SpectrogramAndTargetsTfDataset} from './dataset';
 export {Example, FFT_TYPE, RecognizerParams, SpectrogramData, SpeechCommandRecognizer, SpeechCommandRecognizerMetadata, SpeechCommandRecognizerResult, StreamingRecognitionConfig, TransferLearnConfig, TransferSpeechCommandRecognizer} from './types';
 export {deleteSavedTransferModel, listSavedTransferModels, UNKNOWN_TAG} from './browser_fft_recognizer';
+export {utils};
 export {version} from './version';

--- a/speech-commands/src/types.ts
+++ b/speech-commands/src/types.ts
@@ -139,20 +139,22 @@ export interface ExampleCollectionOptions {
   /**
    * Optional snipppet duration in seconds.
    *
-   * Must be supplied if `snippetCallback` is specified.
+   * Must be supplied if `onSnippet` is specified.
    */
   snippetDurationSec?: number;
 
   /**
    * Optional snippet callback.
    *
-   * Must be supplied if `snippetDurationSec` is specified.
+   * Must be provided if `snippetDurationSec` is specified.
    *
-   * Each invocation of the callback with be conducted with `spectogram`
-   * being the cumulative spectrogram that has been collected since the
-   * beginning of the `collectExample()` call.
+   * The callback will be invoked every `snippetDurationSec` seconds.
+   * Each invocation of the callback with be done with `spectogram`
+   * being the a short spectrogram of duration `snippetDurationSec`.
+   * It is the spectrogram accumulated since the last invocation of the
+   * callback (or for the first time, since when `collectExample()` is started).
    */
-  snippetCallback?: (spectrogram: SpectrogramData) => Promise<void>;
+  onSnippet?: (spectrogram: SpectrogramData) => Promise<void>;
 }
 
 /**

--- a/speech-commands/src/types.ts
+++ b/speech-commands/src/types.ts
@@ -148,11 +148,10 @@ export interface ExampleCollectionOptions {
    *
    * Must be provided if `snippetDurationSec` is specified.
    *
-   * The callback will be invoked every `snippetDurationSec` seconds.
-   * Each invocation of the callback with be done with `spectogram`
-   * being the a short spectrogram of duration `snippetDurationSec`.
-   * It is the spectrogram accumulated since the last invocation of the
-   * callback (or for the first time, since when `collectExample()` is started).
+   * Gets called every snippetDurationSec with a latest slice of the
+   * spectrogram. It is the spectrogram accumulated since the last invocation of
+   * the callback (or for the first time, since when `collectExample()` is
+   * started).
    */
   onSnippet?: (spectrogram: SpectrogramData) => Promise<void>;
 }

--- a/speech-commands/src/types.ts
+++ b/speech-commands/src/types.ts
@@ -135,6 +135,20 @@ export interface ExampleCollectionOptions {
    * If specified, must be >0.
    */
   durationSec?: number;
+
+  /**
+   * Optional snipppet duration in seconds.
+   * 
+   * Must be supplied if `snippetCallback` is specified.
+   */
+  snippetDurationSec?: number;
+
+  /**
+   * Optional snippet callback.
+   * 
+   * Must be supplied if `snippetDurationSec` is specified.
+   */
+  snippetCallback?: (spectrogram: SpectrogramData) => Promise<void>;
 }
 
 /**

--- a/speech-commands/src/types.ts
+++ b/speech-commands/src/types.ts
@@ -147,6 +147,10 @@ export interface ExampleCollectionOptions {
    * Optional snippet callback.
    *
    * Must be supplied if `snippetDurationSec` is specified.
+   *
+   * Each invocation of the callback with be conducted with `spectogram`
+   * being the cumulative spectrogram that has been collected since the
+   * beginning of the `collectExample()` call.
    */
   snippetCallback?: (spectrogram: SpectrogramData) => Promise<void>;
 }

--- a/speech-commands/src/types.ts
+++ b/speech-commands/src/types.ts
@@ -138,14 +138,14 @@ export interface ExampleCollectionOptions {
 
   /**
    * Optional snipppet duration in seconds.
-   * 
+   *
    * Must be supplied if `snippetCallback` is specified.
    */
   snippetDurationSec?: number;
 
   /**
    * Optional snippet callback.
-   * 
+   *
    * Must be supplied if `snippetDurationSec` is specified.
    */
   snippetCallback?: (spectrogram: SpectrogramData) => Promise<void>;
@@ -316,7 +316,7 @@ export interface TransferSpeechCommandRecognizer extends
 
   /**
    * Get metadata about the transfer recognizer.
-   * 
+   *
    * The metadata includes but is not limited to: speech-commands library
    * version, word labels that correspond to the model's probability outputs.
    */


### PR DESCRIPTION
…ample()

- Add `snippetDurationSec` and `snippetCallback` to `collectExample()` to support incrementally-updating spectrogram display during audio data collection. 
- Add unit tests for this new feature.
- Update demo/index.js to demonstrate the new feature.
- Other minor cleanups

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/177)
<!-- Reviewable:end -->
