### PR TITLE
Make sure to use MobileNetV2

### DIFF
--- a/mobilenet/src/index.ts
+++ b/mobilenet/src/index.ts
@@ -20,7 +20,7 @@ import {IMAGENET_CLASSES} from './imagenet_classes';
 
 const IMAGE_SIZE = 224;
 
-export type MobileNetVersion = 1;
+export type MobileNetVersion = 1|2;
 export type MobileNetAlpha = 0.25|0.50|0.75|1.0;
 
 const EMBEDDING_NODES: {[version: string]: string} = {


### PR DESCRIPTION
MobileNetV2 should be available by passing version parameter.

```ts
src/index_test.ts:41:34 - error TS2345: Argument of type '2' is not assignable to parameter of type '1'.

41     const mobilenet = await load(2);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/182)
<!-- Reviewable:end -->
