### PR TITLE
[posenet] Add smoothing pose anomolies option by averaging sequential frames

### DIFF
--- a/body-pix/demos/.babelrc
+++ b/body-pix/demos/.babelrc
@@ -12,7 +12,7 @@
       }
     ]
   ],
-  "plugins": [
-    "transform-runtime"
-  ]
+  // "plugins": [
+  //   "transform-runtime"
+  // ]
 }

--- a/posenet/demos/.babelrc
+++ b/posenet/demos/.babelrc
@@ -12,7 +12,7 @@
       }
     ]
   ],
-  "plugins": [
-    "transform-runtime"
-  ]
+  // "plugins": [
+  //   "transform-runtime"
+  // ]
 }


### PR DESCRIPTION
Sometimes an error in joint inference can cause a pose visualization to look janky which looks broken. A common fix I have implemented (and see it implemented in the “move mirror” demo,) is to estimate the pose over time by taking the average of previous positions, providing a smoothing effect that provides steady motion with lag as a tradeoff.

I have added the logic for this in the demo project, with an option to turn it on/off to varying degrees. Hopefully other users of this model will find it helpful. Keep in mind this only works in “single-pose”

Here is a video demo of the changes
https://youtu.be/Olnx16XvWac

I'm open to any feedback maintainers! Love this project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/187)
<!-- Reviewable:end -->
