### PR TITLE
Allow users of knn to use arbitrary class Id

### DIFF
--- a/knn-classifier/README.md
+++ b/knn-classifier/README.md
@@ -7,7 +7,7 @@ algorithm.
 This package is different from the other packages in this repository in that it
 doesn't provide a model with weights, but rather a utility for constructing a
 KNN model using activations from another model or any other tensors you can
-associate with a class.
+associate with a class/label.
 
 You can see example code [here](https://github.com/tensorflow/tfjs-models/tree/master/knn-classifier/demo).
 
@@ -110,14 +110,14 @@ Returns a `KNNImageClassifier`.
 ```ts
 classifier.addExample(
   example: tf.Tensor,
-  classIndex: number
+  label: number|string
 ): void;
 ```
 
 Args:
 - **example:** An example to add to the dataset, usually an activation from
   another model.
-- **classIndex:** The class index of the example.
+- **label:** The label (class name) of the example.
 
 #### Making a prediction
 
@@ -125,7 +125,7 @@ Args:
 classifier.predictClass(
   input: tf.Tensor,
   k = 3
-): Promise<{classIndex: number, confidences: {[classId: number]: number}}>;
+): Promise<{label: string, classIndex: number, confidences: {[classId: number]: number}}>;
 ```
 
 Args:
@@ -136,19 +136,21 @@ Args:
   the class that appears the most as the final prediction for the input example.
   Defaults to 3. If examples < k, k = examples.
 
-Returns an object with a top classIndex, and confidences mapping all class
-indices to their confidence.
+Returns an object where:
+ - `label`: the label (class name) with the most confidence.
+ - `classIndex`: the 0-based index of the class (for backwards compatibility).
+ - `confidences`: maps each label to their confidence score.
 
 #### Misc
 
 ##### Clear all examples for a class.
 
 ```ts
-classifier.clearClass(classIndex: number)
+classifier.clearClass(label: number|string)
 ```
 
 Args:
-- **classIndex:** The class to clear all examples for.
+- **label:** The label to clear all examples for.
 
 ##### Clear all examples from all classes
 
@@ -159,25 +161,25 @@ classifier.clearAllClasses()
 ##### Get the example count for each class
 
 ```ts
-classifier.getClassExampleCount(): {[classId: number]: number}
+classifier.getClassExampleCount(): {[label: string]: number}
 ```
 
-Returns an object that maps classId to example count for that class.
+Returns an object that maps label name to example count for that label.
 
 ##### Get the full dataset, useful for saving state.
 
 ```ts
-classifier.getClassifierDataset(): {[classId: number]: Tensor2D}
+classifier.getClassifierDataset(): {[label: string]: Tensor2D}
 ```
 
 ##### Set the full dataset, useful for restoring state.
 
 ```ts
-classifier.setClassifierDataset(dataset: {[classId: number]: Tensor2D})
+classifier.setClassifierDataset(dataset: {[label: string]: Tensor2D})
 ```
 
 Args:
-- **dataset:** The class dataset matrices map. Can be retrieved from
+- **dataset:** The label dataset matrices map. Can be retrieved from
   getClassDatsetMatrices. Useful for restoring state.
 
 ##### Get the total number of classes

--- a/knn-classifier/package.json
+++ b/knn-classifier/package.json
@@ -37,7 +37,7 @@
     "publish-npm": "yarn build && npm publish",
     "publish-local": "yarn build && yalc push",
     "lint": "tslint -p . -t verbose",
-    "test": "cd demo && yarn && cd .. && ts-node run_tests.ts"
+    "test": "ts-node run_tests.ts"
   },
   "license": "Apache-2.0"
 }

--- a/knn-classifier/src/index.ts
+++ b/knn-classifier/src/index.ts
@@ -151,13 +151,13 @@ export class KNNClassifier {
   /**
    * Clears the saved examples from the specified class.
    */
-  clearClass(classIndex: number) {
-    if (this.classDatasetMatrices[classIndex] == null) {
-      throw new Error('Cannot clear invalid class ${classIndex}');
+  clearClass(label: number|string) {
+    if (this.classDatasetMatrices[label] == null) {
+      throw new Error(`Cannot clear invalid class ${label}`);
     }
 
-    delete this.classDatasetMatrices[classIndex];
-    delete this.classExampleCount[classIndex];
+    delete this.classDatasetMatrices[label];
+    delete this.classExampleCount[label];
     this.clearTrainDatasetMatrix();
   }
 

--- a/knn-classifier/src/index.ts
+++ b/knn-classifier/src/index.ts
@@ -156,15 +156,7 @@ export class KNNClassifier {
     const topKIndices = topK(await knn.data() as Float32Array, kVal).indices;
     knn.dispose();
 
-    const res = this.calculateTopClass(topKIndices, kVal);
-    // Unmap the internal class index into the user-provided one.
-    res.classIndex = this.unmapClassId[res.classIndex];
-    const newConfidences: {[label: number]: number} = {};
-    for (const classId in res.confidences) {
-      newConfidences[this.unmapClassId[classId]] = res.confidences[classId];
-    }
-    res.confidences = newConfidences;
-    return res;
+    return this.calculateTopClass(topKIndices, kVal);
   }
 
   /**
@@ -247,9 +239,9 @@ export class KNNClassifier {
       const probability = topKCountsForClasses[i] / kVal;
       if (probability > topConfidence) {
         topConfidence = probability;
-        exampleClass = +i;
+        exampleClass = this.unmapClassId[+i];
       }
-      confidences[i] = probability;
+      confidences[this.unmapClassId[+i]] = probability;
     }
 
     return {classIndex: exampleClass, confidences};

--- a/knn-classifier/src/index_test.ts
+++ b/knn-classifier/src/index_test.ts
@@ -81,6 +81,6 @@ describeWithFlags('KNNClassifier', tf.test_util.NODE_ENVS, () => {
     classifier.addExample(tf.tensor1d([9, 9]), 9);
     const result = await classifier.predictClass(tf.tensor1d([5, 5]));
     expect(result.classIndex).toBe(5);
-    expect(result.confidences).toEqual({5: 2/3, 7: 1/3, 9: 0});
+    expect(result.confidences).toEqual({5: 2 / 3, 7: 1 / 3, 9: 0});
   });
 });


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/1478

Users can now pass arbitrary classId/label when calling `addExample()`. The classId/label can be an arbitrary string or number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/188)
<!-- Reviewable:end -->
