### PR TITLE
Remove version from tfjs script tag

### DIFF
--- a/universal-sentence-encoder/README.md
+++ b/universal-sentence-encoder/README.md
@@ -39,7 +39,7 @@ import * as use from '@tensorflow-models/universal-sentence-encoder';
 or as a standalone script tag:
 
 ```js
-<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@1.0.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs"></script>
 <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/universal-sentence-encoder"></script>
 ```
 


### PR DESCRIPTION
It looks like the version number  in the tfjs script tag url is producing an error because of the fix for issue #196.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/202)
<!-- Reviewable:end -->
