### PR TITLE
Ignore `.yalc/` folder when we publish to npm

### DIFF
--- a/body-pix/.npmignore
+++ b/body-pix/.npmignore
@@ -1,3 +1,4 @@
+.yalc/
 .vscode/
 .rpt2_cache/
 scripts/
@@ -17,6 +18,7 @@ karma.conf.js
 CONTRIBUTING.md
 tslint.json
 yarn.lock
+yalc.lock
 DEVELOPMENT.md
 ISSUE_TEMPLATE.md
 PULL_REQUEST_TEMPLATE.md

--- a/coco-ssd/.npmignore
+++ b/coco-ssd/.npmignore
@@ -1,3 +1,4 @@
+.yalc/
 .vscode/
 .rpt2_cache/
 demo/
@@ -13,3 +14,4 @@ dist/**/*.js.map
 .npmignore
 tslint.json
 yarn.lock
+yalc.lock

--- a/coco-ssd/package.json
+++ b/coco-ssd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/coco-ssd",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Object detection model (coco-ssd) in TensorFlow.js",
   "main": "dist/index.js",
   "unpkg": "dist/coco-ssd.min.js",

--- a/knn-classifier/.npmignore
+++ b/knn-classifier/.npmignore
@@ -1,3 +1,4 @@
+.yalc/
 .vscode/
 .rpt2_cache/
 demo/
@@ -12,3 +13,4 @@ dist/**/*.js.map
 .npmignore
 tslint.json
 yarn.lock
+yalc.lock

--- a/mobilenet/.npmignore
+++ b/mobilenet/.npmignore
@@ -1,3 +1,4 @@
+.yalc/
 .vscode/
 .rpt2_cache/
 demos/
@@ -11,4 +12,5 @@ dist/**/*.js.map
 .travis.yml
 .npmignore
 tslint.json
+yalc.lock
 yarn.lock

--- a/posenet/.npmignore
+++ b/posenet/.npmignore
@@ -1,3 +1,4 @@
+.yalc/
 .vscode/
 .rpt2_cache/
 demos/
@@ -12,3 +13,4 @@ dist/**/*.js.map
 .npmignore
 tslint.json
 yarn.lock
+yalc.lock

--- a/speech-commands/.npmignore
+++ b/speech-commands/.npmignore
@@ -1,3 +1,4 @@
+.yalc/
 .vscode/
 .rpt2_cache/
 demo/
@@ -13,3 +14,4 @@ dist/**/*.js.map
 .npmignore
 tslint.json
 yarn.lock
+yalc.lock

--- a/toxicity/.npmignore
+++ b/toxicity/.npmignore
@@ -1,3 +1,4 @@
+.yalc/
 .vscode/
 .rpt2_cache/
 demo/
@@ -13,3 +14,4 @@ tslint.json
 yarn.lock
 images/
 .cache/
+yalc.lock

--- a/universal-sentence-encoder/.npmignore
+++ b/universal-sentence-encoder/.npmignore
@@ -1,3 +1,4 @@
+.yalc/
 .vscode/
 .rpt2_cache/
 demo/
@@ -12,3 +13,4 @@ karma.conf.js
 tslint.json
 yarn.lock
 .cache/
+yalc.lock


### PR DESCRIPTION
Add `.yalc` to `.npmignore` and update the version of coco-ssd so we can republish.

We published coco-ssd with `.yalc` which contains `node_modules`, making the package size exceed 50mb. This results in jsdelivr failing to serve our bundles with the error `Package size exceeded the configured limit of 50 MB.`
: https://cdn.jsdelivr.net/npm/@tensorflow-models/coco-ssd

I verified that all the other models are working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/203)
<!-- Reviewable:end -->
