### PR TITLE
replace XMLHttpRequest with tfjs-core util fetch

### DIFF
--- a/posenet/src/checkpoint_loader.ts
+++ b/posenet/src/checkpoint_loader.ts
@@ -15,8 +15,7 @@
  * =============================================================================
  */
 
-import {Tensor} from '@tensorflow/tfjs';
-
+import {Tensor, util} from '@tensorflow/tfjs';
 /**
  * @hidden
  */
@@ -46,18 +45,18 @@ export class CheckpointLoader {
 
   private loadManifest(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      xhr.open('GET', this.urlPath + MANIFEST_FILE);
-
-      xhr.onload = () => {
-        this.checkpointManifest = JSON.parse(xhr.responseText);
-        resolve();
-      };
-      xhr.onerror = (error) => {
-        throw new Error(
-            `${MANIFEST_FILE} not found at ${this.urlPath}. ${error}`);
-      };
-      xhr.send();
+      util.fetch(this.urlPath + MANIFEST_FILE)
+          .then(async (response: Response) => {
+            if (!response.ok) {
+              throw new Error(
+                  `Not found manifest ${this.urlPath + MANIFEST_FILE}`);
+            }
+            this.checkpointManifest = await response.json();
+            resolve();
+          })
+          .catch(
+              (error: any) => {throw new Error(
+                  `${MANIFEST_FILE} not found at ${this.urlPath}. ${error}`)});
     });
   }
 
@@ -109,24 +108,21 @@ export class CheckpointLoader {
 
     const variableRequestPromiseMethod =
         (resolve: (tensor: Tensor) => void, reject: () => void) => {
-          const xhr = new XMLHttpRequest();
-          xhr.responseType = 'arraybuffer';
           const fname = this.checkpointManifest[varName].filename;
-          xhr.open('GET', this.urlPath + fname);
-
-          xhr.onload = () => {
-            if (xhr.status === 404) {
-              throw new Error(`Not found variable ${varName}`);
-            }
-            const values = new Float32Array(xhr.response);
-            const tensor =
-                Tensor.make(this.checkpointManifest[varName].shape, {values});
-            resolve(tensor);
-          };
-          xhr.onerror = (error) => {
-            throw new Error(`Could not fetch variable ${varName}: ${error}`);
-          };
-          xhr.send();
+          util.fetch(this.urlPath + fname)
+              .then(async (response: Response) => {
+                if (!response.ok) {
+                  throw new Error(`Not found variable ${varName}`);
+                }
+                const values = new Float32Array(await response.arrayBuffer());
+                const tensor = Tensor.make(
+                    this.checkpointManifest[varName].shape, {values});
+                resolve(tensor);
+              })
+              .catch((error: any) => {
+                throw new Error(
+                    `Could not fetch variable ${varName}: ${error}`);
+              });
         };
 
     if (this.checkpointManifest == null) {


### PR DESCRIPTION
replaced the XMLHttpRequest call for loading checkpoints with fetch.
The main reason is on some of the platform (i.e. wechat) XMLHttpRequest is not available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/204)
<!-- Reviewable:end -->
