### PR TITLE
Adds a button to trigger ResNet50 based PoseNet

### DIFF
--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -18,7 +18,7 @@ import * as posenet from '@tensorflow-models/posenet';
 import dat from 'dat.gui';
 import Stats from 'stats.js';
 
-import {drawBoundingBox, drawKeypoints, drawSkeleton} from './demo_util';
+import {drawBoundingBox, drawKeypoints, drawSkeleton, TRY_RESNET50_BUTTON_TEXT} from './demo_util';
 
 const videoWidth = 600;
 const videoHeight = 500;
@@ -75,13 +75,21 @@ async function loadVideo() {
   return video;
 }
 
+const defaultMobileNetMultiplier = isMobile() ? 0.50 : 0.75;
+const defaultMobileNetStride = 16;
+const defaultMobileNetInputResolution = 513;
+
+const defaultResNetMultiplier = 1.0;
+const defaultResNetStride = 32;
+const defaultResNetInputResolution = 257;
+
 const guiState = {
   algorithm: 'multi-pose',
   input: {
-    architecture: isMobile() ? 'MobileNetV1' : 'ResNet50',
-    outputStride: isMobile() ? 16 : 32,
-    inputResolution: 257,
-    multiplier: isMobile() ? 0.50 : 1.0,
+    architecture: 'MobileNetV1',
+    outputStride: defaultMobileNetStride,
+    inputResolution: defaultMobileNetInputResolution,
+    multiplier: defaultMobileNetMultiplier,
   },
   singlePoseDetection: {
     minPoseConfidence: 0.1,
@@ -129,6 +137,10 @@ function setupGui(cameras, net) {
   const architectureController =
       input.add(guiState.input, 'architecture', ['MobileNetV1', 'ResNet50']);
   guiState.architecture = guiState.input.architecture;
+  guiState[TRY_RESNET50_BUTTON_TEXT] = function() {
+    architectureController.setValue('ResNet50')
+  };
+  gui.add(guiState, TRY_RESNET50_BUTTON_TEXT);
   // Input resolution:  Internally, this parameter affects the height and width
   // of the layers in the neural network. The higher the value of the input
   // resolution the better the accuracy but slower the speed.
@@ -186,13 +198,14 @@ function setupGui(cameras, net) {
   }
 
   if (guiState.input.architecture === 'MobileNetV1') {
-    updateGuiInputResolution(513, [257, 353, 449, 513]);
-    updateGuiOutputStride(16, [8, 16]);
-    updateGuiMultiplier(0.50, [0.50, 0.75, 1.0, 1.01])
+    updateGuiInputResolution(
+        defaultMobileNetInputResolution, [257, 353, 449, 513]);
+    updateGuiOutputStride(defaultMobileNetStride, [8, 16]);
+    updateGuiMultiplier(defaultMobileNetMultiplier, [0.50, 0.75, 1.0, 1.01])
   } else {  // guiState.input.architecture === "ResNet50"
-    updateGuiInputResolution(257, [257, 513]);
-    updateGuiOutputStride(32, [32, 16]);
-    updateGuiMultiplier(1.0, [1.0]);
+    updateGuiInputResolution(defaultResNetInputResolution, [257, 513]);
+    updateGuiOutputStride(defaultResNetStride, [32, 16]);
+    updateGuiMultiplier(defaultResNetMultiplier, [1.0]);
   }
 
   input.open();
@@ -227,13 +240,14 @@ function setupGui(cameras, net) {
   architectureController.onChange(function(architecture) {
     // if architecture is ResNet50, then show ResNet50 options
     if (architecture.includes('ResNet50')) {
-      updateGuiInputResolution(257, [257, 513]);
-      updateGuiOutputStride(32, [32, 16]);
-      updateGuiMultiplier(1.0, [1.0]);
+      updateGuiInputResolution(defaultResNetInputResolution, [257, 513]);
+      updateGuiOutputStride(defaultResNetStride, [32, 16]);
+      updateGuiMultiplier(defaultResNetMultiplier, [1.0]);
     } else {  // if architecture is MobileNet, then show MobileNet options
-      updateGuiInputResolution(513, [257, 353, 449, 513]);
-      updateGuiOutputStride(16, [8, 16]);
-      updateGuiMultiplier(0.50, [0.50, 0.75, 1.0, 1.01])
+      updateGuiInputResolution(
+          defaultMobileNetInputResolution, [257, 353, 449, 513]);
+      updateGuiOutputStride(defaultMobileNetStride, [8, 16]);
+      updateGuiMultiplier(defaultMobileNetMultiplier, [0.50, 0.75, 1.0, 1.01])
     }
     guiState.changeToArchitecture = architecture;
   });

--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -18,23 +18,11 @@ import * as posenet from '@tensorflow-models/posenet';
 import dat from 'dat.gui';
 import Stats from 'stats.js';
 
-import {drawBoundingBox, drawKeypoints, drawSkeleton, setDatGuiPropertyCss} from './demo_util';
+import {drawBoundingBox, drawKeypoints, drawSkeleton, isMobile, tryResNetButtonName, tryResNetButtonText, updateTryResNetButtonDatGuiCss} from './demo_util';
 
 const videoWidth = 600;
 const videoHeight = 500;
 const stats = new Stats();
-
-function isAndroid() {
-  return /Android/i.test(navigator.userAgent);
-}
-
-function isiOS() {
-  return /iPhone|iPad|iPod/i.test(navigator.userAgent);
-}
-
-function isMobile() {
-  return isAndroid() || isiOS();
-}
 
 /**
  * Loads a the camera to be used in the demo
@@ -123,17 +111,11 @@ function setupGui(cameras, net) {
   const gui = new dat.GUI({width: 300});
 
   let architectureController = null;
-  const tryResNetButtonName = 'tryResNetButton';
-  const tryResNetButtonText = '[New] Try ResNet50';
-  const tryResNetButtonTextCss = 'width:100%;text-decoration:underline;';
-  const tryResNetButtonBackgroundCss = 'background:#e61d5f;';
   guiState[tryResNetButtonName] = function() {
     architectureController.setValue('ResNet50')
   };
   gui.add(guiState, tryResNetButtonName).name(tryResNetButtonText);
-  setDatGuiPropertyCss(
-      tryResNetButtonText, tryResNetButtonBackgroundCss,
-      tryResNetButtonTextCss);
+  updateTryResNetButtonDatGuiCss();
 
   // The single-pose algorithm is faster and simpler but requires only one
   // person to be in the frame or results will be innaccurate. Multi-pose works

--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -18,7 +18,7 @@ import * as posenet from '@tensorflow-models/posenet';
 import dat from 'dat.gui';
 import Stats from 'stats.js';
 
-import {drawBoundingBox, drawKeypoints, drawSkeleton, TRY_RESNET50_BUTTON_TEXT} from './demo_util';
+import {drawBoundingBox, drawKeypoints, drawSkeleton, setDatGuiPropertyCss} from './demo_util';
 
 const videoWidth = 600;
 const videoHeight = 500;
@@ -122,6 +122,19 @@ function setupGui(cameras, net) {
 
   const gui = new dat.GUI({width: 300});
 
+  let architectureController = null;
+  const tryResNetButtonName = 'tryResNetButton';
+  const tryResNetButtonText = '[New] Try ResNet50';
+  const tryResNetButtonTextCss = 'width:100%;text-decoration:underline;';
+  const tryResNetButtonBackgroundCss = 'background:#e61d5f;';
+  guiState[tryResNetButtonName] = function() {
+    architectureController.setValue('ResNet50')
+  };
+  gui.add(guiState, tryResNetButtonName).name(tryResNetButtonText);
+  setDatGuiPropertyCss(
+      tryResNetButtonText, tryResNetButtonBackgroundCss,
+      tryResNetButtonTextCss);
+
   // The single-pose algorithm is faster and simpler but requires only one
   // person to be in the frame or results will be innaccurate. Multi-pose works
   // for more than 1 person
@@ -134,13 +147,9 @@ function setupGui(cameras, net) {
   // Architecture: there are a few PoseNet models varying in size and
   // accuracy. 1.01 is the largest, but will be the slowest. 0.50 is the
   // fastest, but least accurate.
-  const architectureController =
+  architectureController =
       input.add(guiState.input, 'architecture', ['MobileNetV1', 'ResNet50']);
   guiState.architecture = guiState.input.architecture;
-  guiState[TRY_RESNET50_BUTTON_TEXT] = function() {
-    architectureController.setValue('ResNet50')
-  };
-  gui.add(guiState, TRY_RESNET50_BUTTON_TEXT);
   // Input resolution:  Internally, this parameter affects the height and width
   // of the layers in the neural network. The higher the value of the input
   // resolution the better the accuracy but slower the speed.
@@ -160,7 +169,6 @@ function setupGui(cameras, net) {
       guiState.changeToInputResolution = inputResolution;
     });
   }
-
 
   // Output stride:  Internally, this parameter affects the height and width of
   // the layers in the neural network. The lower the value of the output stride

--- a/posenet/demos/coco.js
+++ b/posenet/demos/coco.js
@@ -18,7 +18,7 @@ import * as posenet from '@tensorflow-models/posenet';
 import * as tf from '@tensorflow/tfjs';
 import dat from 'dat.gui';
 
-import {setDatGuiPropertyCss} from './demo_util';
+import {isMobile, tryResNetButtonName, tryResNetButtonText, updateTryResNetButtonDatGuiCss} from './demo_util';
 
 // clang-format off
 import {
@@ -57,18 +57,6 @@ const images = [
   'tennis_in_crowd.jpg',
   'two_on_bench.jpg',
 ];
-
-function isAndroid() {
-  return /Android/i.test(navigator.userAgent);
-}
-
-function isiOS() {
-  return /iPhone|iPad|iPod/i.test(navigator.userAgent);
-}
-
-function isMobile() {
-  return isAndroid() || isiOS();
-}
 
 /**
  * Draws a pose if it passes a minimum confidence onto a canvas.
@@ -226,17 +214,11 @@ function setupGui(net) {
   const gui = new dat.GUI();
 
   let architectureController = null;
-  const tryResNetButtonName = 'tryResNetButton';
-  const tryResNetButtonText = '[New] Try ResNet50';
-  const tryResNetButtonTextCss = 'width:100%;text-decoration:underline;';
-  const tryResNetButtonBackgroundCss = 'background:#e61d5f;';
   guiState[tryResNetButtonName] = function() {
     architectureController.setValue('ResNet50')
   };
   gui.add(guiState, tryResNetButtonName).name(tryResNetButtonText);
-  setDatGuiPropertyCss(
-      tryResNetButtonText, tryResNetButtonBackgroundCss,
-      tryResNetButtonTextCss);
+  updateTryResNetButtonDatGuiCss();
 
   // Input resolution:  Internally, this parameter affects the height and width
   // of the layers in the neural network. The higher the value of the input

--- a/posenet/demos/coco.js
+++ b/posenet/demos/coco.js
@@ -18,7 +18,7 @@ import * as posenet from '@tensorflow-models/posenet';
 import * as tf from '@tensorflow/tfjs';
 import dat from 'dat.gui';
 
-import {TRY_RESNET50_BUTTON_TEXT} from './demo_util';
+import {setDatGuiPropertyCss} from './demo_util';
 
 // clang-format off
 import {
@@ -224,6 +224,20 @@ let guiState = {
 function setupGui(net) {
   guiState.net = net;
   const gui = new dat.GUI();
+
+  let architectureController = null;
+  const tryResNetButtonName = 'tryResNetButton';
+  const tryResNetButtonText = '[New] Try ResNet50';
+  const tryResNetButtonTextCss = 'width:100%;text-decoration:underline;';
+  const tryResNetButtonBackgroundCss = 'background:#e61d5f;';
+  guiState[tryResNetButtonName] = function() {
+    architectureController.setValue('ResNet50')
+  };
+  gui.add(guiState, tryResNetButtonName).name(tryResNetButtonText);
+  setDatGuiPropertyCss(
+      tryResNetButtonText, tryResNetButtonBackgroundCss,
+      tryResNetButtonTextCss);
+
   // Input resolution:  Internally, this parameter affects the height and width
   // of the layers in the neural network. The higher the value of the input
   // resolution the better the accuracy but slower the speed.
@@ -277,7 +291,7 @@ function setupGui(net) {
   // Architecture: there are a few PoseNet models varying in size and
   // accuracy. 1.01 is the largest, but will be the slowest. 0.50 is the
   // fastest, but least accurate.
-  const architectureController =
+  architectureController =
       model.add(guiState.model, 'architecture', ['MobileNetV1', 'ResNet50']);
   architectureController.onChange(async function(architecture) {
     if (architecture.includes('ResNet50')) {
@@ -298,10 +312,6 @@ function setupGui(net) {
     guiState.model.architecture = architecture;
     reloadNetTestImageAndEstimatePoses(guiState.net);
   });
-  guiState[TRY_RESNET50_BUTTON_TEXT] = function() {
-    architectureController.setValue('ResNet50')
-  };
-  gui.add(guiState, TRY_RESNET50_BUTTON_TEXT);
 
   if (guiState.model.architecture.includes('ResNet50')) {
     updateGuiInputResolution([257, 513]);

--- a/posenet/demos/demo_util.js
+++ b/posenet/demos/demo_util.js
@@ -23,6 +23,20 @@ const color = 'aqua';
 const boundingBoxColor = 'red';
 const lineWidth = 2;
 
+export function setDatGuiPropertyCss(
+    propertyName, liCssString, spanCssString = '') {
+  var spans = document.getElementsByClassName('property-name');
+  for (var i = 0; i < spans.length; i++) {
+    var text = spans[i].textContent || spans[i].innerText;
+    if (text == propertyName) {
+      spans[i].parentNode.parentNode.style = liCssString;
+      if (spanCssString !== '') {
+        spans[i].style = spanCssString;
+      }
+    }
+  }
+}
+
 function toTuple({y, x}) {
   return [y, x];
 }

--- a/posenet/demos/demo_util.js
+++ b/posenet/demos/demo_util.js
@@ -17,24 +17,44 @@
 import * as posenet from '@tensorflow-models/posenet';
 import * as tf from '@tensorflow/tfjs';
 
-export const TRY_RESNET50_BUTTON_TEXT = 'Try ResNet50'
-
 const color = 'aqua';
 const boundingBoxColor = 'red';
 const lineWidth = 2;
 
-export function setDatGuiPropertyCss(
-    propertyName, liCssString, spanCssString = '') {
+export const tryResNetButtonName = 'tryResNetButton';
+export const tryResNetButtonText = '[New] Try ResNet50';
+const tryResNetButtonTextCss = 'width:100%;text-decoration:underline;';
+const tryResNetButtonBackgroundCss = 'background:#e61d5f;';
+
+function isAndroid() {
+  return /Android/i.test(navigator.userAgent);
+}
+
+function isiOS() {
+  return /iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+export function isMobile() {
+  return isAndroid() || isiOS();
+}
+
+function setDatGuiPropertyCss(propertyText, liCssString, spanCssString = '') {
   var spans = document.getElementsByClassName('property-name');
   for (var i = 0; i < spans.length; i++) {
     var text = spans[i].textContent || spans[i].innerText;
-    if (text == propertyName) {
+    if (text == propertyText) {
       spans[i].parentNode.parentNode.style = liCssString;
       if (spanCssString !== '') {
         spans[i].style = spanCssString;
       }
     }
   }
+}
+
+export function updateTryResNetButtonDatGuiCss() {
+  setDatGuiPropertyCss(
+      tryResNetButtonText, tryResNetButtonBackgroundCss,
+      tryResNetButtonTextCss);
 }
 
 function toTuple({y, x}) {

--- a/posenet/demos/demo_util.js
+++ b/posenet/demos/demo_util.js
@@ -17,6 +17,8 @@
 import * as posenet from '@tensorflow-models/posenet';
 import * as tf from '@tensorflow/tfjs';
 
+export const TRY_RESNET50_BUTTON_TEXT = 'Try ResNet50'
+
 const color = 'aqua';
 const boundingBoxColor = 'red';
 const lineWidth = 2;


### PR DESCRIPTION
The ResNet50 model will be triggered only when a user click the "Try ResNet50" button
* Adds a button to coco.js
* Adds a button to camera.js
* Switches default model to MobileNet for both image and camera demo
<img width="306" alt="Screen Shot 2019-05-21 at 11 37 43 PM" src="https://user-images.githubusercontent.com/43684038/58145836-aaa1b480-7c21-11e9-938c-de7203ffe289.png">

TODOs:
* adds a progress bar when downloading the ResNet weights
* exposes 'quantBytes' in the UI


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/214)
<!-- Reviewable:end -->
