### PR TITLE
Exposes `quantBytes` option for ResNet50 demos

### DIFF
--- a/posenet/README.md
+++ b/posenet/README.md
@@ -98,10 +98,10 @@ const net = await posenet.load({
 
  * **multiplier** - Can be one of `1.01`, `1.0`, `0.75`, or `0.50`. The value is used *only* by the MobileNetV1 architecture and not by the ResNet architecture. It is the float multiplier for the depth (number of channels) for all convolution ops. The larger the value, the larger the size of the layers, and more accurate the model at the cost of speed. Set this to a smaller value to increase speed at the cost of accuracy.
 
-**By default,** PoseNet loads a MobileNetV1 architecture with a **`0.75`** multiplier.  This is recommended for computers with **mid-range/lower-end GPUs.**  A model with a **`1.00`** multiplier is recommended for computers with **powerful GPUs.**  A model with a **`0.50`** multiplier is recommended for **mobile.** The ResNet achitecture is recommended for computers with **even more powerful GPUs**.
-
-* **quantBytes** - Can be one of `1`, `2`, `4`. The value is used
+ * **quantBytes** - Can be one of `1`, `2`, `4`. The value is used
  *only* by ResNet50 architecture. This parameter affects weight quantization in the ResNet50 model. The available options are 1 byte, 2 bytes, and 4 bytes. The higher the value, the larger the model size and thus the longer the loading time, the lower the value, the shorter the loading time but lower the accuracy.
+
+**By default,** PoseNet loads a MobileNetV1 architecture with a **`0.75`** multiplier.  This is recommended for computers with **mid-range/lower-end GPUs.**  A model with a **`1.00`** multiplier is recommended for computers with **powerful GPUs.**  A model with a **`0.50`** multiplier is recommended for **mobile.** The ResNet achitecture is recommended for computers with **even more powerful GPUs**.
 
 ### Single-Person Pose Estimation
 

--- a/posenet/README.md
+++ b/posenet/README.md
@@ -100,6 +100,9 @@ const net = await posenet.load({
 
 **By default,** PoseNet loads a MobileNetV1 architecture with a **`0.75`** multiplier.  This is recommended for computers with **mid-range/lower-end GPUs.**  A model with a **`1.00`** multiplier is recommended for computers with **powerful GPUs.**  A model with a **`0.50`** multiplier is recommended for **mobile.** The ResNet achitecture is recommended for computers with **even more powerful GPUs**.
 
+* **quantBytes** - Can be one of `1`, `2`, `4`. The value is used
+ *only* by ResNet50 architecture. This parameter affects weight quantization in the ResNet50 model. The available options are 1 byte, 2 bytes, and 4 bytes. The higher the value, the larger the model size and thus the longer the loading time, the lower the value, the shorter the loading time but lower the accuracy.
+
 ### Single-Person Pose Estimation
 
 Single pose estimation is the simpler and faster of the two algorithms. Its ideal use case is for when there is only one person in the image. The disadvantage is that if there are multiple persons in an image, keypoints from both persons will likely be estimated as being part of the same single pose—meaning, for example, that person #1’s left arm and person #2’s right knee might be conflated by the algorithm as belonging to the same pose. Both the MobileNetV1 and the ResNet architecture support single-person pose estimation. To enable single-person estimation algorithm, **set the `decodingMethod` to 'single-person' in `estimatePoses` using an `InferenceConfig` dictionary**. The returned array will have **one and only one `pose`**:

--- a/posenet/README.md
+++ b/posenet/README.md
@@ -98,8 +98,13 @@ const net = await posenet.load({
 
  * **multiplier** - Can be one of `1.01`, `1.0`, `0.75`, or `0.50`. The value is used *only* by the MobileNetV1 architecture and not by the ResNet architecture. It is the float multiplier for the depth (number of channels) for all convolution ops. The larger the value, the larger the size of the layers, and more accurate the model at the cost of speed. Set this to a smaller value to increase speed at the cost of accuracy.
 
- * **quantBytes** - Can be one of `1`, `2`, `4`. The value is used
- *only* by ResNet50 architecture. This parameter affects weight quantization in the ResNet50 model. The available options are 1 byte, 2 bytes, and 4 bytes. The higher the value, the larger the model size and thus the longer the loading time, the lower the value, the shorter the loading time but lower the accuracy.
+ * **quantBytes** - This argument controls the bytes used for weight quantization. It is *only* used by the ResNet50 model. The available options are:
+
+   - `4`. 4 bytes per float (no quantization). Leads to highest accuracy and original model size (~90MB).
+
+   - `2`. 2 bytes per float. Leads to slightly lower accuracy and 2x model size reduction (~45MB).
+   - `1`. 1 byte per float. Leads to lower accuracy and 4x model size reduction (~22MB).
+
 
 **By default,** PoseNet loads a MobileNetV1 architecture with a **`0.75`** multiplier.  This is recommended for computers with **mid-range/lower-end GPUs.**  A model with a **`1.00`** multiplier is recommended for computers with **powerful GPUs.**  A model with a **`0.50`** multiplier is recommended for **mobile.** The ResNet achitecture is recommended for computers with **even more powerful GPUs**.
 

--- a/posenet/demos/coco.js
+++ b/posenet/demos/coco.js
@@ -176,7 +176,8 @@ async function reloadNetTestImageAndEstimatePoses(net) {
     architecture: guiState.model.architecture,
     outputStride: guiState.model.outputStride,
     inputResolution: guiState.model.inputResolution,
-    multiplier: guiState.model.multiplier
+    multiplier: guiState.model.multiplier,
+    quantBytes: guiState.model.quantBytes,
   });
   testImageAndEstimatePoses(guiState.net);
 }
@@ -184,10 +185,12 @@ async function reloadNetTestImageAndEstimatePoses(net) {
 const defaultMobileNetMultiplier = isMobile() ? 0.50 : 0.75;
 const defaultMobileNetStride = 16;
 const defaultMobileNetInputResolution = 513;
+const defaultMobileNetQuantBytes = 4;
 
 const defaultResNetMultiplier = 1.0;
 const defaultResNetStride = 32;
 const defaultResNetInputResolution = 257;
+const defaultResNetQuantBytes = 2;
 
 let guiState = {
   net: null,
@@ -195,7 +198,8 @@ let guiState = {
     architecture: 'MobileNetV1',
     outputStride: defaultMobileNetStride,
     inputResolution: defaultMobileNetInputResolution,
-    multiplier: defaultMobileNetMultiplier
+    multiplier: defaultMobileNetMultiplier,
+    quantBytes: defaultMobileNetQuantBytes,
   },
   image: 'tennis_in_crowd.jpg',
   multiPoseDetection: {
@@ -270,6 +274,23 @@ function setupGui(net) {
     });
   }
 
+  // QuantBytes: this parameter affects weight quantization in the ResNet50
+  // model. The available options are 1 byte, 2 bytes, and 4 bytes. The higher
+  // the value, the larger the model size and thus the longer the loading time,
+  // the lower the value, the shorter the loading time but lower the accuracy.
+  let quantBytesController = null;
+  function updateQuantBytes(quantBytesArray) {
+    if (quantBytesController) {
+      quantBytesController.remove();
+    }
+    quantBytesController =
+        model.add(guiState.model, 'quantBytes', quantBytesArray);
+    quantBytesController.onChange((quantBytes) => {
+      guiState.model.quantBytes = +quantBytes;
+      reloadNetTestImageAndEstimatePoses(guiState.net);
+    });
+  }
+
   // Architecture: there are a few PoseNet models varying in size and
   // accuracy. 1.01 is the largest, but will be the slowest. 0.50 is the
   // fastest, but least accurate.
@@ -280,16 +301,20 @@ function setupGui(net) {
       guiState.model.inputResolution = defaultResNetInputResolution;
       guiState.model.outputStride = defaultResNetStride;
       guiState.model.multiplier = defaultResNetMultiplier;
+      guiState.model.quantBytes = defaultResNetQuantBytes;
       updateGuiInputResolution([257, 513]);
       updateGuiOutputStride([32, 16]);
       updateGuiMultiplier([1.0]);
+      updateQuantBytes([1, 2, 4])
     } else {
       guiState.model.inputResolution = defaultMobileNetInputResolution;
       guiState.model.outputStride = defaultMobileNetStride;
       guiState.model.multiplier = defaultMobileNetMultiplier;
+      guiState.model.quantBytes = defaultMobileNetQuantBytes;
       updateGuiInputResolution([257, 353, 449, 513]);
       updateGuiOutputStride([8, 16]);
       updateGuiMultiplier([0.5, 0.75, 1.0]);
+      updateQuantBytes([4]);
     }
     guiState.model.architecture = architecture;
     reloadNetTestImageAndEstimatePoses(guiState.net);
@@ -299,10 +324,12 @@ function setupGui(net) {
     updateGuiInputResolution([257, 513]);
     updateGuiOutputStride([32, 16]);
     updateGuiMultiplier([1.0]);
+    updateQuantBytes([1, 2, 4]);
   } else {
     updateGuiInputResolution([257, 513]);
     updateGuiOutputStride([8, 16]);
     updateGuiMultiplier([0.5, 0.75, 1.0]);
+    updateQuantBytes([4]);
   }
 
 
@@ -344,7 +371,8 @@ export async function bindPage() {
     architecture: guiState.model.architecture,
     outputStride: guiState.model.outputStride,
     inputResolution: guiState.model.inputResolution,
-    multiplier: guiState.model.multiplier
+    multiplier: guiState.model.multiplier,
+    quantBytes: guiState.model.quantBytes
   });
 
   setupGui(net);

--- a/posenet/src/checkpoints.ts
+++ b/posenet/src/checkpoints.ts
@@ -19,7 +19,7 @@ import {ConvolutionDefinition, mobileNetArchitectures} from './mobilenet';
 
 const BASE_URL = 'https://storage.googleapis.com/tfjs-models/weights/posenet/';
 const RESNET50_BASE_URL =
-    'https://storage.googleapis.com/tfjs-models/savedmodel/posenet_resnet50/quant2/';
+    'https://storage.googleapis.com/tfjs-models/savedmodel/posenet_resnet50/';
 
 export type Checkpoint = {
   url: string,
@@ -48,18 +48,14 @@ export const checkpoints: {[multiplier: number]: Checkpoint} = {
 // The ResNet50 models use the latest TensorFlow.js 1.0 model format. This is
 // slightly different than the old format used by MobileNetV1 models. Thus we
 // define a new data structure to contain them.
-export const resnet50_checkpoints:
-    {[resolution: number]: {[multiplier: number]: string}} = {
-      801: {
-        32: RESNET50_BASE_URL + 'model-513x513-stride32.json',
-        16: RESNET50_BASE_URL + 'model-513x513-stride16.json',
-      },
-      513: {
-        32: RESNET50_BASE_URL + 'model-513x513-stride32.json',
-        16: RESNET50_BASE_URL + 'model-513x513-stride16.json',
-      },
-      257: {
-        32: RESNET50_BASE_URL + 'model-257x257-stride32.json',
-        16: RESNET50_BASE_URL + 'model-257x257-stride16.json',
-      }
-    };
+export function resNet50Checkpoint(
+    resolution: number, stride: number, quantBytes: number):
+    {[resolution: number]: {[multiplier: number]: string}} {
+  const graphJson = `model-${resolution}x${resolution}-stride${stride}.json`;
+  // quantBytes=4 corresponding to the non-quantized full-precision checkpoints.
+  if (quantBytes == 4) {
+    return RESNET50_BASE_URL + graphJson;
+  } else {
+    return RESNET50_BASE_URL + `quant${quantBytes}/` + graphJson;
+  }
+};

--- a/posenet/src/single_pose/argmax2d_test.ts
+++ b/posenet/src/single_pose/argmax2d_test.ts
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * =============================================================================
+ *
+ =============================================================================
  */
 
 import * as tf from '@tensorflow/tfjs';
@@ -27,7 +28,8 @@ describe('argmax2d', () => {
 
     const expectedResult = tf.tensor2d([1, 1], [1, 2], 'int32');
 
-    tf.test_util.expectArraysClose(result, expectedResult);
+    tf.test_util.expectArraysClose(
+        result.dataSync(), expectedResult.dataSync());
   });
 
   it('x = [3, 3, 1]', () => {
@@ -36,10 +38,12 @@ describe('argmax2d', () => {
         tf.tensor3d([.5, .2, .9, 4.3, .2, .7, .6, -0.11, 1.4], [3, 3, 1]);
 
     tf.test_util.expectArraysClose(
-        argmax2d(input1), tf.tensor2d([2, 1], [1, 2], 'int32'));
+        argmax2d(input1).dataSync(),
+        tf.tensor2d([2, 1], [1, 2], 'int32').dataSync());
 
     tf.test_util.expectArraysClose(
-        argmax2d(input2), tf.tensor2d([1, 0], [1, 2], 'int32'));
+        argmax2d(input2).dataSync(),
+        tf.tensor2d([1, 0], [1, 2], 'int32').dataSync());
   });
 
   it('x = [3, 3, 3]', () => {
@@ -53,6 +57,7 @@ describe('argmax2d', () => {
 
     const expectedResult = tf.tensor2d([2, 1, 1, 0, 2, 1], [3, 2], 'int32');
 
-    tf.test_util.expectArraysClose(result, expectedResult);
+    tf.test_util.expectArraysClose(
+        result.dataSync(), expectedResult.dataSync());
   });
 });


### PR DESCRIPTION
This last PR concludes the ResNet50 model integration for PoseNet. We exposes the `quantBytes` to the users, so they can choose the right quantization level for their own usecase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/218)
<!-- Reviewable:end -->
