### PR TITLE
skip unneeded operation for posenet single-pose

### DIFF
--- a/posenet/src/posenet_model.ts
+++ b/posenet/src/posenet_model.ts
@@ -352,12 +352,12 @@ export class PoseNet {
     displacementFwd = outputs.displacementFwd;
     displacementBwd = outputs.displacementBwd;
 
-    const [scoresBuffer, offsetsBuffer, displacementsFwdBuffer, displacementsBwdBuffer] =
-        await toTensorBuffers3D(
-            [heatmapScores, offsets, displacementFwd, displacementBwd]);
-
     let poses;
     if (config.decodingMethod === 'multi-person') {
+      const [scoresBuffer, offsetsBuffer, displacementsFwdBuffer, displacementsBwdBuffer] =
+          await toTensorBuffers3D(
+              [heatmapScores, offsets, displacementFwd, displacementBwd]);
+
       poses = await decodeMultiplePoses(
           scoresBuffer, offsetsBuffer, displacementsFwdBuffer,
           displacementsBwdBuffer, outputStride, config.maxDetections,


### PR DESCRIPTION
The buffer variables are only necessary for multi-person decoding method and it's also not used for after decoding processing. So it can be self contained on the multi-person block and avoiding this processing for single-pose decoding operation.

On my local tests using the new 2.0 posenet version it's about 15% fps improvement for single pose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/230)
<!-- Reviewable:end -->
