### PR TITLE
narrow the dep to be core and converter only, and clean up the lint errors

### DIFF
--- a/posenet/package.json
+++ b/posenet/package.json
@@ -13,10 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs": "^1.1.0"
+    "@tensorflow/tfjs-core": "^1.1.2",
+    "@tensorflow/tfjs-converter": "^1.1.2"
   },
   "devDependencies": {
-    "@tensorflow/tfjs": "^1.1.0",
+    "@tensorflow/tfjs-core": "^1.1.2",
+    "@tensorflow/tfjs-converter": "^1.1.2",
     "@types/jasmine": "~2.5.53",
     "babel-core": "^6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",

--- a/posenet/src/checkpoint_loader.ts
+++ b/posenet/src/checkpoint_loader.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {Tensor, tensor, util} from '@tensorflow/tfjs';
+import {Tensor, tensor, util} from '@tensorflow/tfjs-core';
 
 /**
  * @hidden
@@ -55,7 +55,7 @@ export class CheckpointLoader {
         resolve();
       } catch (error) {
         throw new Error(
-            `${MANIFEST_FILE} not found at ${this.urlPath}. ${error}`)
+            `${MANIFEST_FILE} not found at ${this.urlPath}. ${error}`);
       }
     });
   }
@@ -120,7 +120,7 @@ export class CheckpointLoader {
         resolve(checkpointTensor);
       } catch (error) {
         throw new Error(`Could not fetch variable ${varName}: ${error}`);
-      };
+      }
     };
 
     if (this.checkpointManifest == null) {

--- a/posenet/src/mobilenet.ts
+++ b/posenet/src/mobilenet.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 import {ModelWeights} from './model_weights';
 import {BaseModel, PoseNetResolution} from './posenet_model';
 

--- a/posenet/src/model_weights.ts
+++ b/posenet/src/model_weights.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 
 export class ModelWeights {
   private variables: {[varName: string]: tf.Tensor};

--- a/posenet/src/posenet_model.ts
+++ b/posenet/src/posenet_model.ts
@@ -15,7 +15,8 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
+import * as tfc from '@tensorflow/tfjs-converter';
 
 import {CheckpointLoader} from './checkpoint_loader';
 import {checkpoints, resNet50Checkpoint} from './checkpoints';
@@ -101,10 +102,12 @@ export interface BaseModel {
  * the accuracy.
  */
 export interface ModelConfig {
-  architecture: PoseNetArchitecture, outputStride: OutputStride,
-      inputResolution: PoseNetResolution, multiplier?: MobileNetMultiplier,
-      modelUrl?: string
-      quantBytes?: PoseNetQuantBytes
+  architecture: PoseNetArchitecture;
+  outputStride: OutputStride;
+  inputResolution: PoseNetResolution; 
+  multiplier?: MobileNetMultiplier;
+  modelUrl?: string;
+  quantBytes?: PoseNetQuantBytes;
 }
 
 // The default configuration for loading MobileNetV1 based PoseNet.
@@ -219,8 +222,11 @@ function validateModelConfig(config: ModelConfig) {
  * than `nmsRadius` pixels away. Defaults to 20.
  */
 export interface InferenceConfig {
-  flipHorizontal: boolean, decodingMethod: PoseNetDecodingMethod,
-      maxDetections?: number, scoreThreshold?: number, nmsRadius?: number
+  flipHorizontal: boolean;
+  decodingMethod: PoseNetDecodingMethod;
+  maxDetections?: number;
+  scoreThreshold?: number; 
+  nmsRadius?: number;
 }
 
 export const SINGLE_PERSON_INFERENCE_CONFIG = {
@@ -254,7 +260,7 @@ function validateInferenceConfig(config: InferenceConfig) {
   }
 
   // Validates parameters used only by multi-person decoding.
-  if (config.decodingMethod == 'multi-person') {
+  if (config.decodingMethod === 'multi-person') {
     if (config.maxDetections == null) {
       config.maxDetections = 5;
     }
@@ -347,7 +353,6 @@ export class PoseNet {
     displacementFwd = outputs.displacementFwd;
     displacementBwd = outputs.displacementBwd;
 
-
     const [scoresBuffer, offsetsBuffer, displacementsFwdBuffer, displacementsBwdBuffer] =
         await toTensorBuffers3D(
             [heatmapScores, offsets, displacementFwd, displacementBwd]);
@@ -368,7 +373,7 @@ export class PoseNet {
     let scaledPoses = scalePoses(poses, scaleY, scaleX, -padTop, -padLeft);
 
     if (config.flipHorizontal) {
-      scaledPoses = flipPosesHorizontal(scaledPoses, width)
+      scaledPoses = flipPosesHorizontal(scaledPoses, width);
     }
 
     heatmapScores.dispose();
@@ -383,7 +388,6 @@ export class PoseNet {
     this.baseModel.dispose();
   }
 }
-
 
 async function loadMobileNet(config: ModelConfig): Promise<PoseNet> {
   const multiplier = config.multiplier;
@@ -440,7 +444,7 @@ async function loadResNet(config: ModelConfig): Promise<PoseNet> {
   }
 
   const url = resNet50Checkpoint(inputResolution, outputStride, quantBytes);
-  const graphModel = await tf.loadGraphModel(config.modelUrl || url);
+  const graphModel = await tfc.loadGraphModel(config.modelUrl || url);
   const resnet = new ResNet(graphModel, inputResolution, outputStride);
   return new PoseNet(resnet);
 }

--- a/posenet/src/posenet_test.ts
+++ b/posenet/src/posenet_test.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 import {describeWithFlags, NODE_ENVS} from '@tensorflow/tfjs-core/dist/jasmine_util';
 import * as posenetModel from './posenet_model';
 import * as resnet from './resnet';
@@ -34,22 +34,22 @@ describeWithFlags('PoseNet', NODE_ENVS, () => {
     // test.
     const resNetConfig = {
       architecture: 'ResNet50',
-      outputStride: outputStride,
-      inputResolution: inputResolution
+      outputStride,
+      inputResolution
     } as posenetModel.ModelConfig;
 
     const mobileNetConfig = {
       architecture: 'MobileNetV1',
-      outputStride: outputStride,
-      inputResolution: inputResolution,
-      multiplier: multiplier
+      outputStride,
+      inputResolution,
+      multiplier
     } as posenetModel.ModelConfig;
 
     spyOn(resnet, 'ResNet').and.callFake(() => {
       return {
-        inputResolution: inputResolution,
-        outputStride: outputStride,
-        predict: function(input: tf.Tensor3D) {
+        inputResolution,
+        outputStride,
+        predict: (input: tf.Tensor3D) => {
           return {
             heatmapScores:
                 tf.zeros([outputResolution, outputResolution, numKeypoints]),
@@ -61,15 +61,15 @@ describeWithFlags('PoseNet', NODE_ENVS, () => {
                 [outputResolution, outputResolution, 2 * (numKeypoints - 1)])
           };
         },
-        dipose: function() {}
+        dipose: () => {}
       };
     });
 
     spyOn(posenetModel.mobilenetLoader, 'load').and.callFake(() => {
       return {
-        inputResolution: inputResolution,
-        outputStride: outputStride,
-        predict: function(input: tf.Tensor3D) {
+        inputResolution,
+        outputStride,
+        predict: (input: tf.Tensor3D) => {
           return {
             heatmapScores:
                 tf.zeros([outputResolution, outputResolution, numKeypoints]),
@@ -81,7 +81,7 @@ describeWithFlags('PoseNet', NODE_ENVS, () => {
                 [outputResolution, outputResolution, 2 * (numKeypoints - 1)])
           };
         },
-        dipose: function() {}
+        dipose: () => {}
       };
     });
 
@@ -89,7 +89,7 @@ describeWithFlags('PoseNet', NODE_ENVS, () => {
         .then((posenetInstance: posenetModel.PoseNet) => {
           resNet = posenetInstance;
         })
-        .then(() => {return posenetModel.load(mobileNetConfig)})
+        .then(() => posenetModel.load(mobileNetConfig))
         .then((posenetInstance: posenetModel.PoseNet) => {
           mobileNet = posenetInstance;
         })
@@ -110,7 +110,7 @@ describeWithFlags('PoseNet', NODE_ENVS, () => {
            .then(
                () => {return mobileNet.estimatePoses(
                    input,
-                   {flipHorizontal: false, decodingMethod: 'single-person'})})
+                   {flipHorizontal: false, decodingMethod: 'single-person'});})
            .then(() => {
              expect(tf.memory().numTensors).toEqual(beforeTensors);
            })
@@ -138,7 +138,7 @@ describeWithFlags('PoseNet', NODE_ENVS, () => {
                    maxDetections: 5,
                    scoreThreshold: 0.5,
                    nmsRadius: 20
-                 })})
+                 });})
            .then(() => {
              expect(tf.memory().numTensors).toEqual(beforeTensors);
            })

--- a/posenet/src/single_pose/argmax2d.ts
+++ b/posenet/src/single_pose/argmax2d.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 
 function mod(a: tf.Tensor1D, b: number): tf.Tensor1D {
   return tf.tidy(() => {

--- a/posenet/src/single_pose/argmax2d_test.ts
+++ b/posenet/src/single_pose/argmax2d_test.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- =============================================================================
+ * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 
 import {argmax2d} from './argmax2d';
 

--- a/posenet/src/single_pose/decode_single_pose.ts
+++ b/posenet/src/single_pose/decode_single_pose.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 
 import {partNames} from '../keypoints';
 import {OutputStride} from '../mobilenet';

--- a/posenet/src/single_pose/util.ts
+++ b/posenet/src/single_pose/util.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 import {NUM_KEYPOINTS} from '../keypoints';
 import {Vector2D} from '../types';
 

--- a/posenet/src/types.ts
+++ b/posenet/src/types.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 
 export type Vector2D = {
   y: number,

--- a/posenet/src/util.ts
+++ b/posenet/src/util.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
 
 import {connectedPartIndices} from './keypoints';
 import {OutputStride} from './mobilenet';
@@ -83,7 +83,7 @@ export async function toTensorBuffers3D(tensors: tf.Tensor3D[]):
 }
 
 export function scalePose(pose: Pose, scaleY: number, scaleX: number,
-   offsetY: number = 0, offsetX: number = 0): Pose {
+   offsetY = 0, offsetX = 0): Pose {
   return {
     score: pose.score,
     keypoints: pose.keypoints.map(
@@ -97,7 +97,7 @@ export function scalePose(pose: Pose, scaleY: number, scaleX: number,
 }
 
 export function scalePoses(poses: Pose[], scaleY: number, scaleX: number,
-  offsetY: number = 0, offsetX: number = 0) {
+  offsetY = 0, offsetX = 0) {
   if (scaleX === 1 && scaleY === 1 && offsetY === 0 && offsetX === 0) {
     return poses;
   }

--- a/posenet/yarn.lock
+++ b/posenet/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-converter@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.1.0.tgz#1d6f58347e9b3826c02090e06e6590b0c4df2d4e"
-  integrity sha512-gUkoRoYm9yrVVQNp8nD+pEWOPUNhayCSrUHNItSfIm8Lzbgx6brVxVdz5T8V0kT0yh67Pp9Er/LIlf54p7KikA==
+"@tensorflow/tfjs-converter@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.1.2.tgz#2400ac77b30f973f1fcb26c912b28271f7f4d605"
+  integrity sha512-KuLIIJYzmRmtJXcjBH3inQVhTHbABj2TNAVS3ss12hzDiEE/RiRb/LZKo8XV2WczuZXTq+gxep84PWXSH/HQXA==
 
-"@tensorflow/tfjs-core@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.0.tgz#028c69291e19c328c4c30e18d29b09135c22cb44"
-  integrity sha512-loPpHGVjiyEb+Ixlsj8prQ/r4exekITn7vM4WEyHUouFKx0/CuoB2FQ0m6DSb/6ApvucxTWGGNTRRo4HK4Ma0Q==
+"@tensorflow/tfjs-core@^1.1.2":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.0.tgz#3c51af02688085a67588a899fe7c847996a761d3"
+  integrity sha512-PF04HsiGiJEllwHpFTSMjoDN4M5RvzoFYwI4QHVyemDY14qz9ngCIzxSLTfCF20JEs/6j7Ep6KQLp0SKa5s61g==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
@@ -19,29 +19,6 @@
     seedrandom "2.4.3"
   optionalDependencies:
     rollup-plugin-visualizer "~1.1.1"
-
-"@tensorflow/tfjs-data@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.1.0.tgz#8d9a0175497930061532c8d43b419b25b26b9bbf"
-  integrity sha512-0+PfAsaZs/pmaxiLunb4c1rPRdu47+CYe5kxpu2P8Xn3k+vhlBYMu+zsVgs5RrTRFLWVzVeH9muA1SJLkMGZPA==
-  dependencies:
-    "@types/node-fetch" "^2.1.2"
-    node-fetch "~2.1.2"
-
-"@tensorflow/tfjs-layers@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.1.0.tgz#fd221c254d2fca13e93e83669bdde3140e7a0434"
-  integrity sha512-a0gXjOWvGi9gc2q8/gK79zfD5WqEZnAhZfpm6b7AoKXjDUBq4GgdbbWCfv2nYBlmMoXgRSRSV44UmJVExep0uw==
-
-"@tensorflow/tfjs@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.1.0.tgz#77809dc336655a7ff0bbf76527cc3d7b9e68e330"
-  integrity sha512-CxcFzl2KtknO3f12xuuv8kq8usMA7xGWpJajubIlYBp4KoBDhiDimP/DwBlTvFZq5RT5riHGtA4BWjMj6rnDcw==
-  dependencies:
-    "@tensorflow/tfjs-converter" "1.1.0"
-    "@tensorflow/tfjs-core" "1.1.0"
-    "@tensorflow/tfjs-data" "1.1.0"
-    "@tensorflow/tfjs-layers" "1.1.0"
 
 "@types/estree@0.0.38":
   version "0.0.38"
@@ -52,13 +29,6 @@
   version "2.5.54"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.54.tgz#a6b5f2ae2afb6e0307774e8c7c608e037d491c63"
   integrity sha512-B9YofFbUljs19g5gBKUYeLIulsh31U5AK70F41BImQRHEZQGm4GcN922UvnYwkduMqbC/NH+9fruWa/zrqvHIg==
-
-"@types/node-fetch@^2.1.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.3.2.tgz#e01893b176c6fa1367743726380d65bce5d6576b"
-  integrity sha512-yW0EOebSsQme9yKu09XbdDfle4/SmWZMK4dfteWcSLCYNQQcF+YOv0kIrvm+9pO11/ghA4E6A+RNQqvYj4Nr3A==
-  dependencies:
-    "@types/node" "*"
 
 "@types/node@*":
   version "11.13.6"


### PR DESCRIPTION
Since the code does not require tfjs-layers or tfjs-data, depending on tfjs union package, would
increase the user binary if they don't need layers or data either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/233)
<!-- Reviewable:end -->
