### PR TITLE
exposing body-pix tensor based ops

### DIFF
--- a/body-pix/src/body_pix_model.ts
+++ b/body-pix/src/body_pix_model.ts
@@ -24,7 +24,7 @@ import {decodePartSegmentation, toMask} from './decode_part_map';
 import {assertValidOutputStride, MobileNet, MobileNetMultiplier, OutputStride} from './mobilenet';
 import {ModelWeights} from './model_weights';
 import {BodyPixInput, PartSegmentation, PersonSegmentation} from './types';
-import {getInputTensorDimensions, resizeAndPadTo, scaleAndCropToInputTensorShape} from './util';
+import {resizeAndPadTo, scaleAndCropToInputTensorShape, toInputTensor} from './util';
 
 const segmentationModelImageDimensions: [number, number] = [353, 257];
 
@@ -74,6 +74,54 @@ export class BodyPix {
    * aspect ratio before feeding through the network. The image pixels
    * should have values [0-255].
    *
+   * @param input tf.Tensor3D
+   * The input image to feed through the network.
+   *
+   * @param outputStride the desired stride for the outputs.  Must be 32, 16,
+   * or 8. Defaults to 16. The output width and height will be will be
+   * (inputDimension - 1)/outputStride + 1
+   *
+   * @param segmentationThreshold The minimum that segmentation values must have
+   * to be considered part of the person.  Affects the generation of the
+   * segmentation mask.
+   *
+   * @return A 2d Tensor with 1 for the pixels that are part of the person,
+   * and 0 otherwise. The width and height correspond to the same dimensions
+   * of the input image.
+   */
+  estimatePersonSegmentationActivation(
+      input: tf.Tensor3D, outputStride: OutputStride = 16,
+      segmentationThreshold = 0.5): tf.Tensor2D {
+    assertValidOutputStride(outputStride);
+
+    return tf.tidy(() => {
+      const {
+        resizedAndPadded,
+        paddedBy,
+      } = resizeAndPadTo(input, segmentationModelImageDimensions);
+
+      const segmentScores =
+          this.predictForSegmentation(resizedAndPadded, outputStride);
+
+      const [resizedHeight, resizedWidth] = resizedAndPadded.shape;
+      const [height, width] = input.shape;
+
+      const scaledSegmentScores = scaleAndCropToInputTensorShape(
+          segmentScores, [height, width], [resizedHeight, resizedWidth],
+          paddedBy);
+
+      return toMask(scaledSegmentScores.squeeze(), segmentationThreshold);
+    });
+  }
+
+  /**
+   * Given an image with a person, returns a binary array with 1 for the pixels
+   * that are part of the person, and 0 otherwise. This does
+   * standard ImageNet pre-processing before inferring through the model. Will
+   * resize and crop the image to 353 x 257 while maintaining the original
+   * aspect ratio before feeding through the network. The image pixels
+   * should have values [0-255].
+   *
    * @param input ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement)
    * The input image to feed through the network.
    *
@@ -94,33 +142,74 @@ export class BodyPix {
   async estimatePersonSegmentation(
       input: BodyPixInput, outputStride: OutputStride = 16,
       segmentationThreshold = 0.5): Promise<PersonSegmentation> {
-    assertValidOutputStride(outputStride);
-
-    const [height, width] = getInputTensorDimensions(input);
-
     const segmentation = tf.tidy(() => {
-      const {
-        resizedAndPadded,
-        paddedBy,
-      } = resizeAndPadTo(input, segmentationModelImageDimensions);
+      const imageTensor = toInputTensor(input);
 
-      const segmentScores =
-          this.predictForSegmentation(resizedAndPadded, outputStride);
-
-      const [resizedHeight, resizedWidth] = resizedAndPadded.shape;
-
-      const scaledSegmentScores = scaleAndCropToInputTensorShape(
-          segmentScores, [height, width], [resizedHeight, resizedWidth],
-          paddedBy);
-
-      return toMask(scaledSegmentScores.squeeze(), segmentationThreshold);
+      return this.estimatePersonSegmentationActivation(
+          imageTensor, outputStride, segmentationThreshold);
     });
 
+    const [height, width] = segmentation.shape;
     const result = await segmentation.data() as Uint8Array;
 
     segmentation.dispose();
 
     return {height, width, data: result};
+  }
+
+  /**
+   * Given an image with a person, returns an array with a part id from 0-24 for
+   * the pixels that are part of a corresponding body part, and -1 otherwise.
+   * This does standard ImageNet pre-processing before inferring through the
+   * model. Will resize and crop the image to 353 x 257 while maintaining the
+   * original aspect ratio before feeding through the network. The image should
+   * pixels should have values [0-255].
+   *
+   * @param input tf.Tensor3D
+   * The input image to feed through the network.
+   *
+   * @param outputStride the desired stride for the outputs.  Must be 32, 16,
+   * or 8. Defaults to 16. The output width and height will be will be
+   * (inputDimension - 1)/outputStride + 1
+   *
+   * @param segmentationThreshold The minimum that segmentation values must have
+   * to be considered part of the person.  Affects the clipping of the colored
+   * part image.
+   *
+   * @return A 2d Tensor with part ids from 0-24 for the pixels that are part of
+   * a corresponding body part, and -1 otherwise. The width and height
+   * correspond to the same dimensions of the input image.
+   */
+  estimatePartSegmentationActivation(
+      input: tf.Tensor3D, outputStride: OutputStride = 16,
+      segmentationThreshold = 0.5): tf.Tensor2D {
+    assertValidOutputStride(outputStride);
+
+    return tf.tidy(() => {
+      const {
+        resizedAndPadded,
+        paddedBy,
+      } = resizeAndPadTo(input, segmentationModelImageDimensions);
+
+      const {segmentScores, partHeatmapScores} =
+          this.predictForPartMap(resizedAndPadded, outputStride);
+
+      const [resizedHeight, resizedWidth] = resizedAndPadded.shape;
+
+      const [height, width] = input.shape;
+      const scaledSegmentScores = scaleAndCropToInputTensorShape(
+          segmentScores, [height, width], [resizedHeight, resizedWidth],
+          paddedBy);
+
+      const scaledPartHeatmapScore = scaleAndCropToInputTensorShape(
+          partHeatmapScores, [height, width], [resizedHeight, resizedWidth],
+          paddedBy);
+
+      const segmentationMask =
+          toMask(scaledSegmentScores.squeeze(), segmentationThreshold);
+
+      return decodePartSegmentation(segmentationMask, scaledPartHeatmapScore);
+    });
   }
 
   /**
@@ -151,35 +240,14 @@ export class BodyPix {
   async estimatePartSegmentation(
       input: BodyPixInput, outputStride: OutputStride = 16,
       segmentationThreshold = 0.5): Promise<PartSegmentation> {
-    assertValidOutputStride(outputStride);
-
-    const [height, width] = getInputTensorDimensions(input);
-
     const partSegmentation = tf.tidy(() => {
-      const {
-        resizedAndPadded,
-        paddedBy,
-      } = resizeAndPadTo(input, segmentationModelImageDimensions);
+      const imageTensor = toInputTensor(input);
 
-      const {segmentScores, partHeatmapScores} =
-          this.predictForPartMap(resizedAndPadded, outputStride);
-
-      const [resizedHeight, resizedWidth] = resizedAndPadded.shape;
-
-      const scaledSegmentScores = scaleAndCropToInputTensorShape(
-          segmentScores, [height, width], [resizedHeight, resizedWidth],
-          paddedBy);
-
-      const scaledPartHeatmapScore = scaleAndCropToInputTensorShape(
-          partHeatmapScores, [height, width], [resizedHeight, resizedWidth],
-          paddedBy);
-
-      const segmentationMask =
-          toMask(scaledSegmentScores.squeeze(), segmentationThreshold);
-
-      return decodePartSegmentation(segmentationMask, scaledPartHeatmapScore);
+      return this.estimatePartSegmentationActivation(
+          imageTensor, outputStride, segmentationThreshold);
     });
 
+    const [height, width] = partSegmentation.shape;
     const data = await partSegmentation.data() as Int32Array;
 
     partSegmentation.dispose();

--- a/body-pix/src/util.ts
+++ b/body-pix/src/util.ts
@@ -2,23 +2,17 @@ import * as tf from '@tensorflow/tfjs-core';
 
 import {BodyPixInput} from './types';
 
-export function getInputTensorDimensions(input: BodyPixInput):
-    [number, number] {
-  return input instanceof tf.Tensor ? [input.shape[0], input.shape[1]] :
-                                      [input.height, input.width];
-}
-
 export function toInputTensor(input: BodyPixInput) {
   return input instanceof tf.Tensor ? input : tf.browser.fromPixels(input);
 }
 
 export function resizeAndPadTo(
-    input: BodyPixInput, [targetH, targetW]: [number, number],
+    imageTensor: tf.Tensor3D, [targetH, targetW]: [number, number],
     flipHorizontal = false): {
   resizedAndPadded: tf.Tensor3D,
   paddedBy: [[number, number], [number, number]]
 } {
-  const [height, width] = getInputTensorDimensions(input);
+  const [height, width] = imageTensor.shape;
 
   const targetAspect = targetW / targetH;
   const aspect = width / height;
@@ -52,7 +46,6 @@ export function resizeAndPadTo(
   }
 
   const resizedAndPadded = tf.tidy(() => {
-    const imageTensor = toInputTensor(input);
     // resize to have largest dimension match image
     let resized: tf.Tensor3D;
     if (flipHorizontal) {


### PR DESCRIPTION
In many of my personal projects I find myself wanting to work with the tensors returned from bodypix, instead of the cpu based output.    This is particularly the case when wanting to do shader based ops on the outputs.

This PR exposes tensor based ops on the `BodyPix` class.

The two new API methods are:
`estimatePersonSegmentationOp`
`estimatePartSegmentationOp`

They both take 3d tensors as inputs and return 2d tensors.

The existing API methods are unchanged.  They wrap the new api methods and convert the output to be cpu based arrays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/275)
<!-- Reviewable:end -->
