### PR TITLE
bump mobilenet version

### DIFF
--- a/mobilenet/package.json
+++ b/mobilenet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/mobilenet",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Pretrained MobileNet in TensorFlow.js",
   "main": "dist/index.js",
   "unpkg": "dist/mobilenet.min.js",

--- a/mobilenet/package.json
+++ b/mobilenet/package.json
@@ -35,8 +35,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc",
-    "publish-local": "yarn build && rollup -c && yalc push",
-    "publish-npm": "yarn build && rollup -c && npm publish",
+    "publish-local": "yarn build && rollup -c && yalc push",    
     "lint": "tslint -p . -t verbose",
     "test": "ts-node run_tests.ts"
   },

--- a/mobilenet/scripts/publish-npm.sh
+++ b/mobilenet/scripts/publish-npm.sh
@@ -1,0 +1,1 @@
+yarn build && npx rollup -c && npm publish


### PR DESCRIPTION
published mobilenet 2.0.2 (https://registry.npmjs.org/@tensorflow-models/mobilenet/-/mobilenet-2.0.2.tgz) is missing some files. This PR would bump the version for a re-publish. We would then deprecate that version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/281)
<!-- Reviewable:end -->
