### PR TITLE
Fix knn-classifier package.json declaration

### DIFF
--- a/knn-classifier/package.json
+++ b/knn-classifier/package.json
@@ -2,7 +2,7 @@
   "name": "@tensorflow-models/knn-classifier",
   "version": "1.2.2",
   "description": "KNN Classifier for TensorFlow.js",
-  "main": "dist/index.js",
+  "main": "dist/knn-classifier.min.js",
   "unpkg": "dist/knn-classifier.min.js",
   "jsdelivr": "dist/knn-classifier.min.js",
   "jsnext:main": "dist/knn-classifier.esm.js",


### PR DESCRIPTION
Because of https://github.com/tensorflow/tfjs-models/blob/master/knn-classifier/rollup.config.js#L61

Otherwise this error occurs:

```
internal/modules/cjs/loader.js:236
      throw err;
      ^

Error: Cannot find module '/node_modules/@tensorflow-models/knn-classifier/dist/index.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (internal/modules/cjs/loader.js:228:19)
    at Function.Module._findPath (internal/modules/cjs/loader.js:365:18)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:610:27)
    at Function.Module._load (internal/modules/cjs/loader.js:527:27)
    at Module.require (internal/modules/cjs/loader.js:681:19)
    at require (internal/modules/cjs/helpers.js:16:16)
    at Object.<anonymous> (/Users/gmorel/Downloads/bug/transfer.js:13:13)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32) {
  code: 'MODULE_NOT_FOUND',
  path: '/node_modules/@tensorflow-models/knn-classifier/package.json',
  requestPath: '@tensorflow-models/knn-classifier'
}
```

Keep up the good work 👍

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/282)
<!-- Reviewable:end -->
