### PR TITLE
dat.gui is not a dev dependency

### DIFF
--- a/posenet/demos/package.json
+++ b/posenet/demos/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tensorflow-models/posenet": "^2.1.1",
     "@tensorflow/tfjs": "^1.1.2",
+    "dat.gui": "^0.7.2",
     "stats.js": "^0.17.0"
   },
   "scripts": {
@@ -30,7 +31,6 @@
     "babel-preset-es2017": "^6.24.1",
     "clang-format": "~1.2.2",
     "cross-env": "^5.2.0",
-    "dat.gui": "^0.7.2",
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
     "parcel-bundler": "~1.10.3",


### PR DESCRIPTION
I've moved the dat.gui to be a normal dependency, not a dev one.
At this moment tools like CodeSandbox fail to run the examples because of this:
https://codesandbox.io/s/github/tensorflow/tfjs-models/tree/master/posenet/demos

With this change the demos run fine: https://codesandbox.io/s/github/valentinvieriu/tfjs-models/tree/master/posenet/demos