### PR TITLE
Posenet - relax input resolution requirement

### DIFF
--- a/posenet/README.md
+++ b/posenet/README.md
@@ -76,7 +76,7 @@ const net = await posenet.load({
 
  * **outputStride** - Can be one of `8`, `16`, `32` (Stride `16`, `32` are supported for the ResNet architecture and stride `8`, `16`, `32` are supported for the MobileNetV1 architecture). It specifies the output stride of the PoseNet model. The smaller the value, the larger the output resolution, and more accurate the model at the cost of speed. Set this to a larger value to increase speed at the cost of accuracy.
 
-* **inputResolution** - Can be one of `161`, `193`, `257`, `289`, `321`, `353`, `385`, `417`, `449`, `481`, `513`, and `801`. Defaults to `257.` It specifies the size the image is resized to before it is fed into the PoseNet model. The larger the value, the more accurate the model at the cost of speed. Set this to a smaller value to increase speed at the cost of accuracy.
+* **inputResolution** - Defaults to `257.` It specifies the size the image is resized to before it is fed into the PoseNet model. The larger the value, the more accurate the model at the cost of speed. Set this to a smaller value to increase speed at the cost of accuracy.
 
  * **multiplier** - Can be one of `1.01`, `1.0`, `0.75`, or `0.50` (The value is used *only* by the MobileNetV1 architecture and not by the ResNet architecture). It is the float multiplier for the depth (number of channels) for all convolution ops. The larger the value, the larger the size of the layers, and more accurate the model at the cost of speed. Set this to a smaller value to increase speed at the cost of accuracy.
 

--- a/posenet/demos/camera.js
+++ b/posenet/demos/camera.js
@@ -211,12 +211,12 @@ function setupGui(cameras, net) {
   function updateGui() {
     if (guiState.input.architecture === 'MobileNetV1') {
       updateGuiInputResolution(
-          defaultMobileNetInputResolution, [257, 353, 449, 513, 801]);
+          defaultMobileNetInputResolution, [257, 300, 353, 449, 513, 700, 801]);
       updateGuiOutputStride(defaultMobileNetStride, [8, 16]);
-      updateGuiMultiplier(defaultMobileNetMultiplier, [0.50, 0.75, 1.0])
+      updateGuiMultiplier(defaultMobileNetMultiplier, [0.50, 0.75, 1.0]);
     } else {  // guiState.input.architecture === "ResNet50"
       updateGuiInputResolution(
-          defaultResNetInputResolution, [257, 353, 449, 513, 801]);
+          defaultResNetInputResolution, [257, 300, 353, 449, 513, 700, 801]);
       updateGuiOutputStride(defaultResNetStride, [32, 16]);
       updateGuiMultiplier(defaultResNetMultiplier, [1.0]);
     }

--- a/posenet/src/index.ts
+++ b/posenet/src/index.ts
@@ -20,7 +20,7 @@ import {decodeMultiplePoses} from './multi_pose/decode_multiple_poses';
 import {decodeSinglePose} from './single_pose/decode_single_pose';
 
 export {partChannels, partIds, partNames, poseChain} from './keypoints';
-export {load, PoseNet, PoseNetOutputStride, VALID_INPUT_RESOLUTION} from './posenet_model';
+export {load, PoseNet, PoseNetOutputStride} from './posenet_model';
 export {Keypoint, Pose} from './types';
 export {getAdjacentKeyPoints, getBoundingBox, getBoundingBoxPoints, scalePose} from './util';
 export {

--- a/posenet/src/mobilenet.ts
+++ b/posenet/src/mobilenet.ts
@@ -23,28 +23,6 @@ import {BaseModel, PoseNetOutputStride} from './posenet_model';
 
 export type MobileNetMultiplier = 0.50|0.75|1.0;
 
-const VALID_OUTPUT_STRIDES = [8, 16, 32];
-// tslint:disable-next-line:no-any
-export function assertValidOutputStride(outputStride: any) {
-  tf.util.assert(
-      typeof outputStride === 'number', () => 'outputStride is not a number');
-  tf.util.assert(
-      VALID_OUTPUT_STRIDES.indexOf(outputStride) >= 0,
-      () => `outputStride of ${outputStride} is invalid. ` +
-          `It must be either 8, 16, or 32`);
-}
-
-// tslint:disable-next-line:no-any
-export function assertValidResolution(resolution: any, outputStride: number) {
-  tf.util.assert(
-      typeof resolution === 'number', () => 'resolution is not a number');
-
-  tf.util.assert(
-      (resolution - 1) % outputStride === 0,
-      () => `resolution of ${resolution} is invalid for output stride ` +
-          `${outputStride}.`);
-}
-
 function toFloatIfInt(input: tf.Tensor3D): tf.Tensor3D {
   return tf.tidy(() => {
     if (input.dtype === 'int32') input = input.toFloat();

--- a/posenet/src/posenet_model.ts
+++ b/posenet/src/posenet_model.ts
@@ -19,15 +19,13 @@ import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
 
 import {mobileNetCheckpoint, resNet50Checkpoint} from './checkpoints';
-import {assertValidOutputStride, assertValidResolution, MobileNet, MobileNetMultiplier} from './mobilenet';
+import {MobileNet, MobileNetMultiplier} from './mobilenet';
 import {decodeMultiplePoses} from './multi_pose/decode_multiple_poses';
 import {ResNet} from './resnet';
 import {decodeSinglePose} from './single_pose/decode_single_pose';
 import {Pose, PosenetInput} from './types';
-import {getInputTensorDimensions, padAndResizeTo, scaleAndFlipPoses, toTensorBuffers3D} from './util';
+import {assertValidOutputStride, assertValidResolution, getInputTensorDimensions, getValidInputResolution, padAndResizeTo, scaleAndFlipPoses, toTensorBuffers3D} from './util';
 
-export type PoseNetInputResolution =
-    161|193|257|289|321|353|385|417|449|481|513|801|1217;
 export type PoseNetOutputStride = 32|16|8;
 export type PoseNetArchitecture = 'ResNet50'|'MobileNetV1';
 export type PoseNetDecodingMethod = 'single-person'|'multi-person';
@@ -78,6 +76,11 @@ export interface BaseModel {
  * at the cost of accuracy. Stride 32 is supported for ResNet and
  * stride 8,16,32 are supported for various MobileNetV1 models.
  *
+ * * `inputResolution`:Specifies the size the input image is scaled to before
+ * feeding it through the PoseNet model.  The larger the value, more accurate
+ * the model at the cost of speed. Set this to a smaller value to increase
+ * speed at the cost of accuracy.
+ *
  * `multiplier`: An optional number with values: 1.01, 1.0, 0.75, or
  * 0.50. The value is used only by MobileNet architecture. It is the float
  * multiplier for the depth (number of channels) for all convolution ops.
@@ -98,7 +101,7 @@ export interface BaseModel {
 export interface ModelConfig {
   architecture: PoseNetArchitecture;
   outputStride: PoseNetOutputStride;
-  inputResolution: PoseNetInputResolution;
+  inputResolution: number;
   multiplier?: MobileNetMultiplier;
   modelUrl?: string;
   quantBytes?: PoseNetQuantBytes;
@@ -128,8 +131,7 @@ const VALID_STRIDE = {
   'MobileNetV1': [8, 16, 32],
   'ResNet50': [32, 16]
 };
-export const VALID_INPUT_RESOLUTION =
-    [161, 193, 257, 289, 321, 353, 385, 417, 449, 481, 513, 801];
+
 const VALID_MULTIPLIER = {
   'MobileNetV1': [0.50, 0.75, 1.0],
   'ResNet50': [1.0]
@@ -152,10 +154,10 @@ function validateModelConfig(config: ModelConfig) {
     config.inputResolution = 257;
   }
 
-  if (VALID_INPUT_RESOLUTION.indexOf(config.inputResolution) < 0) {
+  if (typeof (config.inputResolution) !== 'number') {
     throw new Error(
         `Invalid inputResolution ${config.inputResolution}. ` +
-        `Should be one of ${VALID_INPUT_RESOLUTION}`);
+        `Should be a number`);
   }
 
   if (config.outputStride == null) {
@@ -198,11 +200,6 @@ function validateModelConfig(config: ModelConfig) {
  * This should be set to true for videos where the video is by default flipped
  * horizontally (i.e. a webcam), and you want the poses to be returned in the
  * proper orientation.
- *
- * `inputResolution`:Specifies the size the input image is scaled to before
- * feeding it through the PoseNet model.  The larger the value, more accurate
- * the model at the cost of speed. Set this to a smaller value to increase
- * speed at the cost of accuracy.
  *
  */
 export interface InferenceConfig {
@@ -279,10 +276,13 @@ function validateMultiPersonInputConfig(config: MultiPersonInferenceConfig) {
 }
 
 export class PoseNet {
-  baseModel: BaseModel;
-  inputResolution: PoseNetInputResolution;
+  readonly baseModel: BaseModel;
+  readonly inputResolution: number;
 
-  constructor(net: BaseModel, inputResolution: PoseNetInputResolution) {
+  constructor(net: BaseModel, inputResolution: number) {
+    assertValidOutputStride(net.outputStride);
+    assertValidResolution(inputResolution, net.outputStride);
+
     this.baseModel = net;
     this.inputResolution = inputResolution;
   }
@@ -320,9 +320,6 @@ export class PoseNet {
 
     const outputStride = this.baseModel.outputStride;
     const inputResolution = this.inputResolution;
-
-    assertValidOutputStride(outputStride);
-    assertValidResolution(this.inputResolution, outputStride);
 
     const [height, width] = getInputTensorDimensions(input);
 
@@ -386,8 +383,6 @@ export class PoseNet {
 
     const outputStride = this.baseModel.outputStride;
     const inputResolution = this.inputResolution;
-    assertValidOutputStride(outputStride);
-    assertValidResolution(inputResolution, outputStride);
 
     const [height, width] = getInputTensorDimensions(input);
 
@@ -445,7 +440,11 @@ async function loadMobileNet(config: ModelConfig): Promise<PoseNet> {
   const url = mobileNetCheckpoint(outputStride, multiplier, quantBytes);
   const graphModel = await tfconv.loadGraphModel(config.modelUrl || url);
   const mobilenet = new MobileNet(graphModel, outputStride);
-  return new PoseNet(mobilenet, config.inputResolution);
+
+  const validInputResolution =
+      getValidInputResolution(config.inputResolution, mobilenet.outputStride);
+
+  return new PoseNet(mobilenet, validInputResolution);
 }
 
 async function loadResNet(config: ModelConfig): Promise<PoseNet> {
@@ -461,7 +460,9 @@ async function loadResNet(config: ModelConfig): Promise<PoseNet> {
   const url = resNet50Checkpoint(outputStride, quantBytes);
   const graphModel = await tfconv.loadGraphModel(config.modelUrl || url);
   const resnet = new ResNet(graphModel, outputStride);
-  return new PoseNet(resnet, config.inputResolution);
+  const validInputResolution =
+      getValidInputResolution(config.inputResolution, resnet.outputStride);
+  return new PoseNet(resnet, validInputResolution);
 }
 
 /**

--- a/posenet/src/posenet_test.ts
+++ b/posenet/src/posenet_test.ts
@@ -108,6 +108,39 @@ describeWithFlags('PoseNet', NODE_ENVS, () => {
         .catch(done.fail);
   });
 
+  it('load with mobilenet returns a model with a valid input resolution',
+     (done) => {
+       const outputStride = 16;
+       const mobilenetModelConfig: posenetModel.ModelConfig = {
+         architecture: 'MobileNetV1',
+         outputStride,
+         multiplier: 0.75,
+         inputResolution: outputStride * 10 + 5
+       };
+
+       posenetModel.load(mobilenetModelConfig).then(model => {
+         expect(model.inputResolution).toEqual(outputStride * 10 + 1);
+
+         done();
+       });
+     });
+
+  it('load with resnet returns a model with a valid input resolution',
+     (done) => {
+       const outputStride = 32;
+       const mobilenetModelConfig: posenetModel.ModelConfig = {
+         architecture: 'ResNet50',
+         outputStride,
+         multiplier: 1.00,
+         inputResolution: outputStride * 10 + 4
+       };
+
+       posenetModel.load(mobilenetModelConfig).then(model => {
+         expect(model.inputResolution).toEqual(outputStride * 10 + 1);
+
+         done();
+       });
+     });
   it('estimateSinglePose does not leak memory', done => {
     const input =
         tf.zeros([inputResolution, inputResolution, 3]) as tf.Tensor3D;

--- a/posenet/src/util.ts
+++ b/posenet/src/util.ts
@@ -128,9 +128,45 @@ export function flipPosesHorizontal(poses: Pose[], imageWidth: number) {
 export function getValidResolution(
     imageScaleFactor: number, inputDimension: number,
     outputStride: PoseNetOutputStride): number {
-  const evenResolution = inputDimension * imageScaleFactor - 1;
+  return getValidInputResolution(
+      inputDimension * imageScaleFactor, outputStride);
+}
+
+function toEvenNumber(value: number): number {
+  if (value % 2 === 0) {
+    return value;
+  } else {
+    return value - 1;
+  }
+}
+
+export function getValidInputResolution(
+    inputResolution: number, outputStride: PoseNetOutputStride): number {
+  const evenResolution = toEvenNumber(inputResolution);
 
   return evenResolution - (evenResolution % outputStride) + 1;
+}
+
+const VALID_OUTPUT_STRIDES = [8, 16, 32];
+// tslint:disable-next-line:no-any
+export function assertValidOutputStride(outputStride: number) {
+  tf.util.assert(
+      typeof outputStride === 'number', () => 'outputStride is not a number');
+  tf.util.assert(
+      VALID_OUTPUT_STRIDES.indexOf(outputStride) >= 0,
+      () => `outputStride of ${outputStride} is invalid. ` +
+          `It must be either 8, 16, or 32`);
+}
+
+export function assertValidResolution(
+    resolution: number, outputStride: number) {
+  tf.util.assert(
+      typeof resolution === 'number', () => 'resolution is not a number');
+
+  tf.util.assert(
+      (resolution - 1) % outputStride === 0,
+      () => `resolution of ${resolution} is invalid for output stride ` +
+          `${outputStride}.`);
 }
 
 export function getInputTensorDimensions(input: PosenetInput):

--- a/posenet/src/util_test.ts
+++ b/posenet/src/util_test.ts
@@ -15,28 +15,79 @@
  * =============================================================================
  */
 
-import {getValidResolution} from './util';
+import {assertValidResolution, getValidInputResolution, getValidResolution} from './util';
 
-describe('util.getValidResolution', () => {
-  it('returns an odd value', () => {
-    expect(getValidResolution(0.5, 545, 32) % 2).toEqual(1);
-    expect(getValidResolution(0.5, 545, 16) % 2).toEqual(1);
-    expect(getValidResolution(0.5, 545, 8) % 2).toEqual(1);
-    expect(getValidResolution(0.845, 242, 8) % 2).toEqual(1);
-    expect(getValidResolution(0.421, 546, 16) % 2).toEqual(1);
+describe('util', () => {
+  describe('getValidResolution', () => {
+    it('returns an odd value', () => {
+      expect(getValidResolution(0.5, 545, 32) % 2).toEqual(1);
+      expect(getValidResolution(0.5, 545, 16) % 2).toEqual(1);
+      expect(getValidResolution(0.5, 545, 8) % 2).toEqual(1);
+      expect(getValidResolution(0.845, 242, 8) % 2).toEqual(1);
+      expect(getValidResolution(0.421, 546, 16) % 2).toEqual(1);
+    });
+
+    it('returns a value that when 1 is subtracted by it is ' +
+           'divisible by the output stride',
+       () => {
+         const outputStride = 32;
+         const imageSize = 562;
+
+         const scaleFactor = 0.63;
+
+         const resolution =
+             getValidResolution(scaleFactor, imageSize, outputStride);
+
+         expect((resolution - 1) % outputStride).toEqual(0);
+       });
   });
 
-  it('returns a value that when 1 is subtracted by it is ' +
-         'divisible by the output stride',
-     () => {
-       const outputStride = 32;
-       const imageSize = 562;
+  describe('getValidInputResolution', () => {
+    it('returns an odd value', () => {
+      expect(getValidInputResolution(1920, 8) % 2).toEqual(1);
+      expect(getValidInputResolution(1280, 16) % 2).toEqual(1);
+      expect(getValidInputResolution(719, 16) % 2).toEqual(1);
+      expect(getValidInputResolution(545, 16) % 2).toEqual(1);
+      expect(getValidInputResolution(225, 8) % 2).toEqual(1);
+      expect(getValidInputResolution(240, 8) % 2).toEqual(1);
+    });
 
-       const scaleFactor = 0.63;
+    it('returns a value that when 1 is subtracted by it is ' +
+           'divisible by the output stride',
+       () => {
+         const outputStride = 8;
+         const inputResolution = 562;
 
-       const resolution =
-           getValidResolution(scaleFactor, imageSize, outputStride);
+         const resolution =
+             getValidInputResolution(inputResolution, outputStride);
 
-       expect((resolution - 1) % outputStride).toEqual(0);
-     });
+         expect((resolution - 1) % outputStride).toEqual(0);
+       });
+  });
+
+  describe('assertValidResolution', () => {
+    it('raises an error when one subtracted by the input resolution is ' +
+           'not divisible by the output stride',
+       () => {
+         expect(() => {
+           assertValidResolution(16 * 5, 16);
+         }).toThrow();
+         expect(() => {
+           assertValidResolution(8 * 10, 8);
+         }).toThrow();
+         expect(() => {
+           assertValidResolution(32 * 10 + 5, 32);
+         }).toThrow();
+       });
+    it('does not raise an error when one subtracted by the input resolution is ' +
+           'divisible by the output stride',
+       () => {
+         expect(() => {
+           assertValidResolution(16 * 5 + 1, 16);
+         }).not.toThrow();
+         expect(() => {
+           assertValidResolution(32 * 10 + 1, 32);
+         }).not.toThrow();
+       });
+  });
 });


### PR DESCRIPTION
This PR modifies the `posenet.load` function to allow any input resolution, and internally adjusts the input resolution to one that has its corresponding odd value be divisible by the output stride.

This makes the API easier to consume and easier to understand.

* Some "invalid" input resolutions were added to the demo as a form of test;  internally those invalid resolutions will be adjusted to be valid resolutions.

Added some tests around validation of the input resolution and setting it when the model is loaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/293)
<!-- Reviewable:end -->
