### PR TITLE
simplifies and speeds up USE trie

### DIFF
--- a/universal-sentence-encoder/src/tokenizer/trie.ts
+++ b/universal-sentence-encoder/src/tokenizer/trie.ts
@@ -18,15 +18,13 @@
 import {stringToChars} from '../util';
 
 // [token, score, index]
-// TODO fix typing
-// type OutputNode = [string[], number, number];
-type OutputNode = any; 
+type OutputNode = [string[], number, number];
 
 class TrieNode {
   public parent: TrieNode;
   public end: boolean;
   public children: {[firstSymbol: string]: TrieNode};
-  public word: OutputNode[];
+  public word: OutputNode;
 
   constructor() {
     this.parent = null;
@@ -77,11 +75,11 @@ export class Trie {
     let node = this.root.children[ss[0]];
 
     for (let i = 0; i < ss.length && node; i++){
-      if (node.end) output.push(node.word);
+      if (node.end){ output.push(node.word); }
       node = node.children[ss[i + 1]];
     }
 
-    if (!output.length) output.push([[ss[0]], 0, 0]);
+    if (!output.length){ output.push([[ss[0]], 0, 0]); }
 
     return output;
   }

--- a/universal-sentence-encoder/src/tokenizer/trie.ts
+++ b/universal-sentence-encoder/src/tokenizer/trie.ts
@@ -18,39 +18,21 @@
 import {stringToChars} from '../util';
 
 // [token, score, index]
-type OutputNode = [string[], number, number];
+// TODO fix typing
+// type OutputNode = [string[], number, number];
+type OutputNode = any; 
 
 class TrieNode {
   public parent: TrieNode;
   public end: boolean;
   public children: {[firstSymbol: string]: TrieNode};
-  public score: number;
-  public index: number;
+  public word: OutputNode[];
 
-  private key: string;
-
-  constructor(key: string) {
-    this.key = key;
+  constructor() {
     this.parent = null;
     this.children = {};
     this.end = false;
-  }
-
-  /**
-   * Traverse upwards through the trie to construct the token.
-   */
-  getWord(): OutputNode {
-    const output: string[] = [];
-    let node: TrieNode = this;
-
-    while (node !== null) {
-      if (node.key !== null) {
-        output.unshift(node.key);
-      }
-      node = node.parent;
-    }
-
-    return [output, this.score, this.index];
+    this.word = [[], 0, 0];
   }
 }
 
@@ -58,27 +40,7 @@ export class Trie {
   public root: TrieNode;
 
   constructor() {
-    this.root = new TrieNode(null);
-  }
-
-  /**
-   * Checks whether a node starts with ss.
-   *
-   * @param ss The prefix.
-   * @param node The node currently being considered.
-   * @param arr An array of the matching tokens uncovered so far.
-   */
-  findAllCommonPrefixes(ss: string[], node: TrieNode, arr: OutputNode[]) {
-    if (node.end) {
-      const word = node.getWord();
-      if (ss.slice(0, word[0].length).join('') === word[0].join('')) {
-        arr.unshift(word);
-      }
-    }
-
-    for (const child in node.children) {
-      this.findAllCommonPrefixes(ss, node.children[child], arr);
-    }
+    this.root = new TrieNode();
   }
 
   /**
@@ -91,16 +53,16 @@ export class Trie {
 
     for (let i = 0; i < symbols.length; i++) {
       if (!node.children[symbols[i]]) {
-        node.children[symbols[i]] = new TrieNode(symbols[i]);
+        node.children[symbols[i]] = new TrieNode();
         node.children[symbols[i]].parent = node;
+        node.children[symbols[i]].word[0] = node.word[0].concat(symbols[i]);
       }
 
       node = node.children[symbols[i]];
-
       if (i === symbols.length - 1) {
         node.end = true;
-        node.score = score;
-        node.index = index;
+        node.word[1] = score;
+        node.word[2] = index;
       }
     }
   }
@@ -111,13 +73,16 @@ export class Trie {
    * @param ss The prefix to match on.
    */
   commonPrefixSearch(ss: string[]): OutputNode[] {
-    const node = this.root.children[ss[0]];
     const output: OutputNode[] = [];
-    if (node) {
-      this.findAllCommonPrefixes(ss, node, output);
-    } else {
-      output.push([[ss[0]], 0, 0]);  // unknown token
+    let node = this.root.children[ss[0]];
+
+    for (let i = 0; i < ss.length && node; i++){
+      if (node.end) output.push(node.word);
+      node = node.children[ss[i + 1]];
     }
+
+    if (!output.length) output.push([[ss[0]], 0, 0]);
+
     return output;
   }
 }

--- a/universal-sentence-encoder/src/trie_test.ts
+++ b/universal-sentence-encoder/src/trie_test.ts
@@ -33,6 +33,7 @@ describe('Universal Sentence Encoder tokenizer', () => {
     const commonPrefixes =
         tokenizer.trie.commonPrefixSearch(['l', 'i', 'k', 'e'])
             .map(d => d[0].join(''));
-    expect(commonPrefixes).toEqual(['like', 'l']);
+
+    expect(commonPrefixes).toEqual(['l', 'like']);
   });
 });


### PR DESCRIPTION
This removes recursive branching and caches array creation.  

```
import {loadTokenizer} from './index'

loadTokenizer().then(tokenizer => {

  var gettysburg = 'Fourscore and seven years ago our fathers brought forth, on this continent, a new nation, conceived in liberty, and dedicated to the proposition that all men are created equal. Now we are engaged in a great civil war, testing whether that nation, or any nation so conceived, and so dedicated, can long endure. We are met on a great battle-field of that war. We have come to dedicate a portion of that field, as a final resting-place for those who here gave their lives, that that nation might live. It is altogether fitting and proper that we should do this. But, in a larger sense, we cannot dedicate, we cannot consecrate—we cannot hallow—this ground. The brave men, living and dead, who struggled here, have consecrated it far above our poor power to add or detract. The world will little note, nor long remember what we say here, but it can never forget what they did here. It is for us the living, rather, to be dedicated here to the unfinished work which they who fought here have thus far so nobly advanced. It is rather for us to be here dedicated to the great task remaining before us—that from these honored dead we take increased devotion to that cause for which they here gave the last full measure of devotion—that we here highly resolve that these dead shall not have died in vain—that this nation, under God, shall have a new birth of freedom, and that government of the people, by the people, for the people, shall not perish from the earth.'

  console.time('gettysburg')
  var tokens = tokenizer.encode(gettysburg)
  console.timeEnd('gettysburg') // 1650 ms -> 17 ms!
});
```

I also tried a simple hash, but at 40 ms it is slower than the trie; performance is closely tied to the longest token in the vocab. 

```
module.exports = function(){
  const hash = {}
  let longestToken = 0

  function insert(word, score, index){
    const symbols = []
    for (const symbol of word) {
      symbols.push(symbol)
    }

    hash[symbols] = [symbols, score, index]
    longestToken = Math.max(longestToken, symbols.length)
  }

  function commonPrefixSearch(symbols){
    const rv = symbols
      .slice(0, longestToken + 1)
      .map((d, i) => hash[symbols.slice(0, i + 1)])
      .filter(d => d)

    return rv.length ? rv : [[symbols[0]], 0, 0]
  }

  return {insert, commonPrefixSearch}
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/299)
<!-- Reviewable:end -->
