### PR TITLE
Update MobileNet v2 to use fused kernels.

### DIFF
--- a/mobilenet/package.json
+++ b/mobilenet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/mobilenet",
-  "version": "2.0.4",
+  "version": "2.1.4",
   "description": "Pretrained MobileNet in TensorFlow.js",
   "main": "dist/index.js",
   "unpkg": "dist/mobilenet.min.js",
@@ -13,12 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.1",
-    "@tensorflow/tfjs-converter": "~1.2.1"
+    "@tensorflow/tfjs-core": "~1.2.11",
+    "@tensorflow/tfjs-converter": "~1.2.11"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.1",
-    "@tensorflow/tfjs-converter": "~1.2.1",
+    "@tensorflow/tfjs-core": "~1.2.11",
+    "@tensorflow/tfjs-converter": "~1.2.11",
     "@types/jasmine": "~2.5.53",
     "babel-core": "^6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc",
-    "publish-local": "yarn build && rollup -c && yalc push",    
+    "publish-local": "yarn build && rollup -c && yalc push",
     "lint": "tslint -p . -t verbose",
     "test": "ts-node run_tests.ts"
   },

--- a/mobilenet/src/index.ts
+++ b/mobilenet/src/index.ts
@@ -45,7 +45,6 @@ export interface ModelConfig {
   alpha?: MobileNetAlpha;
   modelUrl?: string|tf.io.IOHandler;
   inputRange?: [number, number];
-
 }
 
 const EMBEDDING_NODES: {[version: string]: string} = {
@@ -86,17 +85,17 @@ const MODEL_INFO: {[version: string]: {[alpha: string]: MobileNetInfo}} = {
   '2.00': {
     '0.50': {
       url:
-          'https://tfhub.dev/google/imagenet/mobilenet_v2_050_224/classification/2',
+          'https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_050_224/classification/2/default/1',
       inputRange: [0, 1]
     },
     '0.75': {
       url:
-          'https://tfhub.dev/google/imagenet/mobilenet_v2_075_224/classification/2',
+          'https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_075_224/classification/2/default/1',
       inputRange: [0, 1]
     },
     '1.00': {
       url:
-          'https://tfhub.dev/google/imagenet/mobilenet_v2_100_224/classification/2',
+          'https://tfhub.dev/google/tfjs-model/imagenet/mobilenet_v2_100_224/classification/2/default/1',
       inputRange: [0, 1]
     }
   }
@@ -208,7 +207,8 @@ class MobileNetImpl implements MobileNet {
 
       // Normalize the image from [0, 255] to [inputMin, inputMax].
       const normalized =
-          img.toFloat().mul(this.normalizationConstant).add(this.inputMin) as tf.Tensor3D;
+          img.toFloat().mul(this.normalizationConstant).add(this.inputMin) as
+          tf.Tensor3D;
 
       // Resize the image to
       let resized = normalized;

--- a/mobilenet/yarn.lock
+++ b/mobilenet/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-converter@~1.2.1":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.2.tgz#c95e2f79b1de830b8079c7704dc8463ced2d2b79"
-  integrity sha512-NM2NcPRHpCNeJdBxHcYpmW9ZHTQ2lJFJgmgGpQ8CxSC9CtQB05bFONs3SKcwMNDE/69QBRVom5DYqLCVUg+A+g==
+"@tensorflow/tfjs-converter@~1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.11.tgz#c81a8bde669179e20e676dba790eeca61fa6ce0a"
+  integrity sha512-3Qg3k6x9ZbAFSCJTSC2anaM40Fs04+PGFw/uRvupWHmns6D5ni9RzTH2thef9hzBT2V/UHnlnHs7RYJqQNTThA==
 
-"@tensorflow/tfjs-core@~1.2.1":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.2.tgz#2efa89e323612a26aeccee9b3ae9f5ac5a635bbe"
-  integrity sha512-2hCHMKjh3UNpLEjbAEaurrTGJyj/KpLtMSAraWgHA1vGY0kmk50BBSbgCDmXWUVm7lyh/SkCq4/GrGDZktEs3g==
+"@tensorflow/tfjs-core@~1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.11.tgz#6bd870338cece217610613600ed4c20fdd13e201"
+  integrity sha512-guqqD5bb5BTaTvUVWhG1xCXB0NuA5rv0indSEEOpMfqqBvtSwKp02heDGDcPOSUnmdB8V/HJbcyX2wRBXztQpA==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"
@@ -18,8 +18,6 @@
     "@types/webgl2" "0.0.4"
     node-fetch "~2.1.2"
     seedrandom "2.4.3"
-  optionalDependencies:
-    rollup-plugin-visualizer "~1.1.1"
 
 "@types/estree@0.0.38":
   version "0.0.38"
@@ -563,11 +561,6 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
 isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -734,13 +727,6 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-opn@^5.4.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
-  integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
-  dependencies:
-    is-wsl "^1.1.0"
-
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
@@ -864,16 +850,6 @@ rollup-plugin-uglify@~3.0.0:
   dependencies:
     uglify-es "^3.3.7"
 
-rollup-plugin-visualizer@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-1.1.1.tgz#454ae0aed23845407ebfb81cc52114af308d6d90"
-  integrity sha512-7xkSKp+dyJmSC7jg2LXqViaHuOnF1VvIFCnsZEKjrgT5ZVyiLLSbeszxFcQSfNJILphqgAEmWAUz0Z4xYScrRw==
-  dependencies:
-    mkdirp "^0.5.1"
-    opn "^5.4.0"
-    source-map "^0.7.3"
-    typeface-oswald "0.0.54"
-
 rollup-pluginutils@^2.0.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.0.tgz#478ace04bd7f6da2e724356ca798214884738fc4"
@@ -929,11 +905,6 @@ source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 strip-ansi@^3.0.0:
   version "3.0.1"
@@ -1006,11 +977,6 @@ tsutils@^2.12.1:
   integrity sha512-qf6rmT84TFMuxAKez2pIfR8UCai49iQsfB7YWVjV1bKpy/d0PWT5rEOSM6La9PiHZ0k1RRZQiwVdVJfQ3BPHgg==
   dependencies:
     tslib "^1.8.1"
-
-typeface-oswald@0.0.54:
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/typeface-oswald/-/typeface-oswald-0.0.54.tgz#1e253011622cdd50f580c04e7d625e7f449763d7"
-  integrity sha512-U1WMNp4qfy4/3khIfHMVAIKnNu941MXUfs3+H9R8PFgnoz42Hh9pboSFztWr86zut0eXC8byalmVhfkiKON/8Q==
 
 typescript@3.3.3333:
   version "3.3.3333"


### PR DESCRIPTION
#### Changes

- Update tfjs dependency to 1.2.11
- Update tfhub URLs

#### Benchmarks

Benchmarks are calculated for MobileNet v2 100, average of 50 runs.

|| Master  | update_mobilenet |
|------------- | ------------- | ------------ |
| # of kernels | 178 | 107 |
|MBP F32| 24.5ms  | 19.8ms *(1.24x)*  |
|Pixel3 F32| 99.1ms  | 88.5ms *(1.12x)*  |
|MBP F16| 22.7ms | 20.6ms *(1.1x)* |
|Pixel3 F16| 88.1ms | 77.8ms *(1.13x)* |
|iPhoneX| 23.4ms  | 21.6ms *(1.1x)*  |


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/306)
<!-- Reviewable:end -->
