### PR TITLE
set default stride for MobileNet backbone to 16

### DIFF
--- a/body-pix/src/body_pix_model.ts
+++ b/body-pix/src/body_pix_model.ts
@@ -134,7 +134,7 @@ export interface ModelConfig {
 
 const MOBILENET_V1_CONFIG = {
   architecture: 'MobileNetV1',
-  outputStride: 32,
+  outputStride: 16,
   inputResolution: 513,
   quantBytes: 4,
   multiplier: 0.75,


### PR DESCRIPTION
This should fix the following bug:
https://github.com/tensorflow/tfjs/issues/2182

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/307)
<!-- Reviewable:end -->
