### PR TITLE
[BodyPix ]- allow input width and height to be specified for resolution.  Auto-set valid input resolution.

### DIFF
--- a/body-pix/README.md
+++ b/body-pix/README.md
@@ -113,7 +113,7 @@ If you want to load other versions of the model, specify the architecture explic
 const net = await bodyPix.load({
   architecture: 'ResNet50',
   outputStride: 32,
-  inputResolution: 257,
+  inputResolution: { width: 640, height: 480 },
   quantBytes: 2
 });
 ```
@@ -123,7 +123,7 @@ const net = await bodyPix.load({
 const net = await bodyPix.load({
   architecture: 'MobileNetV1',
   outputStride: 16,
-  inputResolution: 513,
+  inputResolution: { width: 257, height: 200 },
   multiplier: 0.75
 });
 ```
@@ -134,7 +134,7 @@ const net = await bodyPix.load({
 
  * **outputStride** - Can be one of `8`, `16`, `32` (Stride `16`, `32` are supported for the ResNet architecture and stride `8`, `16`, `32` are supported for the MobileNetV1 architecture). It specifies the output stride of the BodyPix model. The smaller the value, the larger the output resolution, and more accurate the model at the cost of speed.  ***A larger value results in a smaller model and faster prediction time but lower accuracy***.
 
-* **inputResolution** - Can be one of `161`, `193`, `257`, `289`, `321`, `353`, `385`, `417`, `449`, `481`, `513`, and `801`. Defaults to `257.` It specifies the size the image is resized to before it is fed into the BodyPix model. The larger the value, the more accurate the model at the cost of speed. ***A smaller value results in a smaller model and faster prediction time but lower accuracy***.
+* **inputResolution** - A `number` or an `Object` of type `{width: number, height: number}`. Defaults to `257.` It specifies the size the image is resized and padded to before it is fed into the PoseNet model. The larger the value, the more accurate the model at the cost of speed. Set this to a smaller value to increase speed at the cost of accuracy. If a number is provided, the image will be resized and padded to be a square with the same width and height.  If `width` and `height` are provided, the image will be resized and padded to the specified width and height. ***A smaller value results in a smaller model and faster prediction time but lower accuracy***.
 
  * **multiplier** - Can be one of `1.0`, `0.75`, or `0.50` (The value is used *only* by the MobileNetV1 architecture and not by the ResNet architecture). It is the float multiplier for the depth (number of channels) for all convolution ops. The larger the value, the larger the size of the layers, and more accurate the model at the cost of speed. ***A smaller value results in a smaller model and faster prediction time but lower accuracy***.
 

--- a/body-pix/demos/index.js
+++ b/body-pix/demos/index.js
@@ -157,11 +157,11 @@ const defaultQuantBytes = 2;
 
 const defaultMobileNetMultiplier = isMobile() ? 0.50 : 0.75;
 const defaultMobileNetStride = 16;
-const defaultMobileNetInputResolution = 513;
+const defaultMobileNetInputResolution = 500;
 
 const defaultResNetMultiplier = 1.0;
 const defaultResNetStride = 16;
-const defaultResNetInputResolution = 257;
+const defaultResNetInputResolution = 250;
 
 const guiState = {
   algorithm: 'multi-person-instance',
@@ -340,12 +340,14 @@ function setupGui(cameras) {
   function updateGuiInputSection() {
     if (guiState.input.architecture === 'MobileNetV1') {
       updateGuiInputResolution(
-          defaultMobileNetInputResolution, [257, 353, 449, 513, 801]);
+          defaultMobileNetInputResolution,
+          [200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800]);
       updateGuiOutputStride(defaultMobileNetStride, [8, 16]);
       updateGuiMultiplier(defaultMobileNetMultiplier, [0.50, 0.75, 1.0])
     } else {  // guiState.input.architecture === "ResNet50"
       updateGuiInputResolution(
-          defaultResNetInputResolution, [257, 353, 449, 513, 801]);
+          defaultResNetInputResolution,
+          [200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800]);
       updateGuiOutputStride(defaultResNetStride, [32, 16]);
       updateGuiMultiplier(defaultResNetMultiplier, [1.0]);
     }

--- a/body-pix/src/mobilenet.ts
+++ b/body-pix/src/mobilenet.ts
@@ -22,28 +22,6 @@ import {BaseModel, BodyPixOutputStride} from './body_pix_model';
 
 export type MobileNetMultiplier = 0.50|0.75|1.0;
 
-const VALID_OUTPUT_STRIDES = [8, 16, 32];
-// tslint:disable-next-line:no-any
-export function assertValidOutputStride(outputStride: any) {
-  tf.util.assert(
-      typeof outputStride === 'number', () => 'outputStride is not a number');
-  tf.util.assert(
-      VALID_OUTPUT_STRIDES.indexOf(outputStride) >= 0,
-      () => `outputStride of ${outputStride} is invalid. ` +
-          `It must be either 8, 16, or 32`);
-}
-
-// tslint:disable-next-line:no-any
-export function assertValidResolution(resolution: any, outputStride: number) {
-  tf.util.assert(
-      typeof resolution === 'number', () => 'resolution is not a number');
-
-  tf.util.assert(
-      (resolution - 1) % outputStride === 0,
-      () => `resolution of ${resolution} is invalid for output stride ` +
-          `${outputStride}.`);
-}
-
 function toFloatIfInt(input: tf.Tensor3D): tf.Tensor3D {
   return tf.tidy(() => {
     if (input.dtype === 'int32') {

--- a/body-pix/src/output_rendering_util.ts
+++ b/body-pix/src/output_rendering_util.ts
@@ -174,7 +174,7 @@ export function toMask(
     return null;
   }
 
-  let multiPersonOrPartSegmentation: (PersonSegmentation|PartSegmentation)[];
+  let multiPersonOrPartSegmentation: Array<PersonSegmentation|PartSegmentation>;
   if (!Array.isArray(personOrPartSegmentation)) {
     multiPersonOrPartSegmentation = [personOrPartSegmentation];
   } else {

--- a/body-pix/src/types.ts
+++ b/body-pix/src/types.ts
@@ -19,7 +19,10 @@ export type PartSegmentation = {
 };
 
 export declare interface Padding {
-  top: number; bottom: number; left: number; right: number;
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
 }
 
 export declare type Part = {
@@ -57,3 +60,5 @@ export declare type Color = {
   b: number,
   a: number,
 };
+
+export declare type InputResolution = number | {width: number, height: number};


### PR DESCRIPTION
Relaxes input resolution validation to allow any number, and automatically sets the input resolution to something that is valid for the output stride.

Adds tests around input resolution.

Fixes [#2185](https://github.com/tensorflow/tfjs/issues/2185)
Inspired by #296

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/313)
<!-- Reviewable:end -->
