### PR TITLE
Add cloud build scripts to run individual cloudbuild.yml's

### DIFF
--- a/body-pix/cloudbuild.yml
+++ b/body-pix/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'body-pix'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/body-pix/cloudbuild.yml
+++ b/body-pix/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'body-pix'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'body-pix'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'body-pix'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-models-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/body-pix/cloudbuild.yml
+++ b/body-pix/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -96,7 +96,7 @@ secrets:
   secretEnv:
     BROWSERSTACK_KEY: CiQAkwyoIW0LcnxymzotLwaH4udVTQFBEN4AEA5CA+a3+yflL2ASPQAD8BdZnGARf78MhH5T9rQqyz9HNODwVjVIj64CTkFlUCGrP1B2HX9LXHWHLmtKutEGTeFFX9XhuBzNExA=
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 options:
   logStreamingOption: 'STREAM_ON'
   substitution_option: 'ALLOW_LOOSE'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -40,7 +40,7 @@ secrets:
   secretEnv:
     BROWSERSTACK_KEY: CiQAkwyoIW0LcnxymzotLwaH4udVTQFBEN4AEA5CA+a3+yflL2ASPQAD8BdZnGARf78MhH5T9rQqyz9HNODwVjVIj64CTkFlUCGrP1B2HX9LXHWHLmtKutEGTeFFX9XhuBzNExA=
 timeout: 1800s
-logsBucket: 'gs://tfjs-build-logs'
+logsBucket: 'gs://tfjs-models-build-logs'
 options:
   logStreamingOption: 'STREAM_ON'
   substitution_option: 'ALLOW_LOOSE'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -14,6 +14,62 @@ steps:
   - 'COMMIT_SHA=$COMMIT_SHA'
   - 'BRANCH_NAME=$BRANCH_NAME'
 
+# Body pix.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'body-pix'
+  args: ['./scripts/run-build.sh', 'body-pix']
+  waitFor: ['diff']
+
+# Coco SSD.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'coco-ssd'
+  args: ['./scripts/run-build.sh', 'coco-ssd']
+  waitFor: ['diff']
+
+# Deeplab.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'deeplab'
+  args: ['./scripts/run-build.sh', 'deep-lab']
+  waitFor: ['diff']
+
+# KNN Classifier.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'knn-classifier'
+  args: ['./scripts/run-build.sh', 'knn-classifier']
+  waitFor: ['diff']
+
+# Mobilenet.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'mobilenet'
+  args: ['./scripts/run-build.sh', 'mobilenet']
+  waitFor: ['diff']
+
+# Posenet.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'posenet'
+  args: ['./scripts/run-build.sh', 'posenet']
+  waitFor: ['diff']
+
+# Speech commands.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'speech-commands'
+  args: ['./scripts/run-build.sh', 'speech-commands']
+  waitFor: ['diff']
+
+# Toxicity.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'toxicity'
+  args: ['./scripts/run-build.sh', 'toxicity']
+  waitFor: ['diff']
+
 # Universal sentence encoder.
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -14,6 +14,14 @@ steps:
   - 'COMMIT_SHA=$COMMIT_SHA'
   - 'BRANCH_NAME=$BRANCH_NAME'
 
+# Universal sentence encoder.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  id: 'universal-sentence-encoder'
+  args: ['./scripts/run-build.sh', 'universal-sentence-encoder']
+  waitFor: ['diff']
+
+# Run the top-level sanity checks.
 - name: 'node:10'
   entrypoint: 'yarn'
   id: 'test'

--- a/coco-ssd/cloudbuild.yml
+++ b/coco-ssd/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'coco-ssd'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/coco-ssd/cloudbuild.yml
+++ b/coco-ssd/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'coco-ssd'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'coco-ssd'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'coco-ssd'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-models-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/coco-ssd/cloudbuild.yml
+++ b/coco-ssd/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/deeplab/cloudbuild.yml
+++ b/deeplab/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'universal-sentence-encoder'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/deeplab/cloudbuild.yml
+++ b/deeplab/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/deeplab/cloudbuild.yml
+++ b/deeplab/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'universal-sentence-encoder'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'universal-sentence-encoder'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'universal-sentence-encoder'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-models-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/knn-classifier/cloudbuild.yml
+++ b/knn-classifier/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'knn-classifier'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'knn-classifier'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'knn-classifier'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-models-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/knn-classifier/cloudbuild.yml
+++ b/knn-classifier/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'knn-classifier'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/knn-classifier/cloudbuild.yml
+++ b/knn-classifier/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/mobilenet/cloudbuild.yml
+++ b/mobilenet/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'mobilenet'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'mobilenet'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'mobilenet'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-models-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/mobilenet/cloudbuild.yml
+++ b/mobilenet/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/mobilenet/cloudbuild.yml
+++ b/mobilenet/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'mobilenet'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/posenet/cloudbuild.yml
+++ b/posenet/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'posenet'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'posenet'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'posenet'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-models-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/posenet/cloudbuild.yml
+++ b/posenet/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'posenet'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/posenet/cloudbuild.yml
+++ b/posenet/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/presubmit.ts
+++ b/presubmit.ts
@@ -31,7 +31,7 @@ const dirs = fs.readdirSync(dir)
                  .filter(f => !f.startsWith('.') && f !== 'node_modules');
 
 dirs.forEach(dir => {
-  if (!fs.existsSync(`${dir}/package.json`)) {
+  if (!fs.existsSync(`${dir}/package.json`) || dir === 'clone') {
     return;
   }
 

--- a/presubmit.ts
+++ b/presubmit.ts
@@ -31,25 +31,15 @@ const dirs = fs.readdirSync(dir)
                  .filter(f => !f.startsWith('.') && f !== 'node_modules');
 
 dirs.forEach(dir => {
-  if (dir === 'scripts' || dir === 'clone') {
+  if (!fs.existsSync(`${dir}/package.json`)) {
     return;
   }
+
   console.log(`~~~~~~~~~~~~ Building ${dir} ~~~~~~~~~~~~`);
 
   shell.cd(dir);
-  shell.exec('yarn');
-  shell.exec('yarn build');
 
   const pkg = JSON.parse(fs.readFileSync('package.json').toString());
-  if (pkg['scripts']['test'] != null) {
-    console.log(`************ Testing ${dir} ************`);
-    shell.exec('yarn test');
-  } else {
-    console.warn(
-        `WARNING: ${dir} has no unit tests! ` +
-        `Please consider adding unit tests to this model directory.`);
-  }
-
   // Make sure peer dependencies and dev dependencies of tfjs match, and make
   // sure the version uses ^.
   const peerDeps = pkg.peerDependencies;

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+set -e
+
+DIR=$1
+if test -f "$DIR/diff"; then
+  gcloud builds submit . --config=$DIR/cloudbuild.yml
+fi

--- a/speech-commands/cloudbuild.yml
+++ b/speech-commands/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'speech-commands'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/speech-commands/cloudbuild.yml
+++ b/speech-commands/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'speech-commands'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'speech-commands'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'speech-commands'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-models-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/speech-commands/cloudbuild.yml
+++ b/speech-commands/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/toxicity/cloudbuild.yml
+++ b/toxicity/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'toxicity'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'toxicity'
+  entrypoint: 'yarn'
+  id: 'build'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'toxicity'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-models-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/toxicity/cloudbuild.yml
+++ b/toxicity/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'toxicity'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/toxicity/cloudbuild.yml
+++ b/toxicity/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/universal-sentence-encoder/cloudbuild.yml
+++ b/universal-sentence-encoder/cloudbuild.yml
@@ -1,0 +1,40 @@
+steps:
+
+# Install common dependencies.
+- name: 'node:10'
+  id: 'yarn-common'
+  entrypoint: 'yarn'
+  args: ['install']
+
+# Install tfjs dependencies.
+- name: 'node:10'
+  dir: 'universal-sentence-encoder'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['install']
+  waitFor: ['yarn-common']
+
+# Build.
+- name: 'node:10'
+  dir: 'universal-sentence-encoder'
+  entrypoint: 'yarn'
+  id: 'yarn'
+  args: ['build']
+  waitFor: ['yarn']
+
+# Run tests.
+- name: 'node:10'
+  dir: 'universal-sentence-encoder'
+  entrypoint: 'yarn'
+  id: 'test'
+  args: ['test-ci']
+  waitFor: ['yarn']
+
+# General configuration
+timeout: 1800s
+logsBucket: 'gs://tfjs-build-logs'
+substitutions:
+  _NIGHTLY: ''
+options:
+  logStreamingOption: 'STREAM_ON'
+  substitution_option: 'ALLOW_LOOSE'

--- a/universal-sentence-encoder/cloudbuild.yml
+++ b/universal-sentence-encoder/cloudbuild.yml
@@ -18,7 +18,7 @@ steps:
 - name: 'node:10'
   dir: 'universal-sentence-encoder'
   entrypoint: 'yarn'
-  id: 'yarn'
+  id: 'build'
   args: ['build']
   waitFor: ['yarn']
 
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-build-logs'
+logsBucket: 'gs://tfjs-models-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:

--- a/universal-sentence-encoder/cloudbuild.yml
+++ b/universal-sentence-encoder/cloudbuild.yml
@@ -27,7 +27,7 @@ steps:
   dir: 'universal-sentence-encoder'
   entrypoint: 'yarn'
   id: 'test'
-  args: ['test-ci']
+  args: ['test']
   waitFor: ['yarn']
 
 # General configuration

--- a/universal-sentence-encoder/cloudbuild.yml
+++ b/universal-sentence-encoder/cloudbuild.yml
@@ -32,7 +32,7 @@ steps:
 
 # General configuration
 timeout: 1800s
-logsBucket: 'gs://tfjs-models-build-logs'
+logsBucket: 'gs://tfjs-build-logs'
 substitutions:
   _NIGHTLY: ''
 options:


### PR DESCRIPTION
This mirrors the monorepo.

No functional changes except parallelizing the build and only running the subset of tests necessary.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/331)
<!-- Reviewable:end -->
