### PR TITLE
BodyPix - change internalResolution to map to a percentage

### DIFF
--- a/body-pix/README-v2.md
+++ b/body-pix/README-v2.md
@@ -174,7 +174,8 @@ const segmentation = await net.segmentPerson(image, {
    The input image to feed through the network.
 * **config** - an optional dictionary containing:
   * **flipHorizontal** - Defaults to false.  If the segmentation & pose should be flipped/mirrored horizontally.  This should be set to true for videos where the video is by default flipped horizontally (i.e. a webcam), and you want the segmentation & pose to be returned in the proper orientation.
-  * **internalResolution** - Defaults to 'medium'. The internal resolution used by the model. The larger the internal resolution the more accurate the model at the cost of slower prediction times. Available values are 'low', 'medium', 'high' or a positive number.
+ * **internalResolution** - Defaults to `medium`. The internal resolution percentage that input is resized to before inference. The larger the `internalResolution` the more accurate the model at the cost of slower prediction times. Available values are `low`, `medium`, `high`, `full`, or a percentage value between 0 and 1. The values `low`, `medium`, `high`, and
+`full` map to 0.25, 0.5, 0.75, and 1.0 correspondingly.
   * **segmentationThreshold** - Defaults to 0.7. Must be between 0 and 1. For each pixel, the model estimates a score between 0 and 1 that indicates how confident it is that part of a person is displayed in that pixel.  This *segmentationThreshold* is used to convert these values
 to binary 0 or 1s by determining the minimum value a pixel's score must have to be considered part of a person.  In essence, a higher value will create a tighter crop
 around a person but may result in some pixels being that are part of a person being excluded from the returned segmentation mask.

--- a/body-pix/demos/index.js
+++ b/body-pix/demos/index.js
@@ -337,12 +337,13 @@ function setupGui(cameras) {
   function updateGuiInputSection() {
     if (guiState.input.architecture === 'MobileNetV1') {
       updateGuiInternalResolution(
-          defaultMobileNetInternalResolution, ['low', 'medium', 'high']);
+          defaultMobileNetInternalResolution,
+          ['low', 'medium', 'high', 'full']);
       updateGuiOutputStride(defaultMobileNetStride, [8, 16]);
       updateGuiMultiplier(defaultMobileNetMultiplier, [0.50, 0.75, 1.0])
     } else {  // guiState.input.architecture === "ResNet50"
       updateGuiInternalResolution(
-          defaultResNetInternalResolution, ['low', 'medium', 'high']);
+          defaultResNetInternalResolution, ['low', 'medium', 'high', 'full']);
       updateGuiOutputStride(defaultResNetStride, [32, 16]);
       updateGuiMultiplier(defaultResNetMultiplier, [1.0]);
     }

--- a/body-pix/src/body_pix_model.ts
+++ b/body-pix/src/body_pix_model.ts
@@ -28,7 +28,7 @@ import {ResNet} from './resnet';
 import {mobileNetSavedModel, resNet50SavedModel} from './saved_models';
 import {decodeSinglePose} from './single_person/decode_single_pose';
 import {BodyPixArchitecture, BodyPixInput, BodyPixInternalResolution, BodyPixMultiplier, BodyPixOutputStride, BodyPixQuantBytes, Padding, PartSegmentation, PersonSegmentation} from './types';
-import {getInputSize, padAndResizeTo, scaleAndCropToInputTensorShape, scaleAndFlipPoses, toTensorBuffers3D, toValidInternalResolutionNumber} from './util';
+import {getInputSize, padAndResizeTo, scaleAndCropToInputTensorShape, scaleAndFlipPoses, toInputResolutionHeightAndWidth, toTensorBuffers3D} from './util';
 
 const APPLY_SIGMOID_ACTIVATION = true;
 
@@ -153,10 +153,12 @@ function validateModelConfig(config: ModelConfig) {
  * and you want the person & body part segmentation to be returned in the proper
  * orientation.
  *
- * `internalResolution`: Defaults to 'medium'. The internal resolution used by
- * the model. The larger the internal resolution the more accurate the model at
- * the cost of slower prediction times. Available values are 'low', 'medium',
- * 'high' or a positive number.
+ * `internalResolution`: Defaults to 'medium'. The internal resolution
+ * percentage that the input is resized to before inference. The larger the
+ * internalResolution the more accurate the model at the cost of slower
+ * prediction times. Available values are 'low', 'medium', 'high', 'full', or a
+ * percentage value between 0 and 1. The values 'low', 'medium', 'high', and
+ * 'full' map to 0.25, 0.5, 0.75, and 1.0 correspondingly.
  *
  * `segmentationThreshold`: The minimum that segmentation values must
  * have to be considered part of the person. Affects the generation of the
@@ -274,7 +276,6 @@ function validateMultiPersonInstanceInferenceConfig(
 
 export class BodyPix {
   baseModel: BaseModel;
-  internalResolution: number;
 
   constructor(net: BaseModel) {
     this.baseModel = net;
@@ -367,10 +368,12 @@ export class BodyPix {
    * @param input ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement)
    * The input image to feed through the network.
    *
-   * @param internalResolution`: Defaults to 'medium'. The internal resolution
-   * used by the model. The larger the internal resolution the more accurate the
-   * model at the cost of slower prediction times. Available values are 'low',
-   * 'medium', 'high' or a positive number.
+   * @param internalResolution Defaults to 'medium'. The internal resolution
+   * that input is resized to before inference. The larger the
+   * internalResolution the more accurate the model at the cost of slower
+   * prediction times. Available values are 'low', 'medium', 'high', 'full', or
+   * a percentage value between 0 and 1. The values 'low', 'medium', 'high', and
+   * 'full' map to 0.25, 0.5, 0.75, and 1.0 correspondingly.
    *
    * @param segmentationThreshold The minimum that segmentation values must have
    * to be considered part of the person. Affects the generation of the
@@ -394,14 +397,14 @@ export class BodyPix {
     segmentation: tf.Tensor2D,
     heatmapScores: tf.Tensor3D,
     offsets: tf.Tensor3D,
-    padding: Padding
+    padding: Padding,
+    internalResolutionHeightAndWidth: [number, number]
   } {
     const [height, width] = getInputSize(input);
-    const validInternalResolution =
-        toValidInternalResolutionNumber(internalResolution);
-    this.internalResolution = validInternalResolution;
-    const {resized, padding} = padAndResizeTo(
-        input, [validInternalResolution, validInternalResolution]);
+    const internalResolutionHeightAndWidth = toInputResolutionHeightAndWidth(
+        internalResolution, this.baseModel.outputStride, [height, width]);
+    const {resized, padding} =
+        padAndResizeTo(input, internalResolutionHeightAndWidth);
 
     const {segmentation, heatmapScores, offsets} = tf.tidy(() => {
       const {
@@ -425,7 +428,13 @@ export class BodyPix {
       };
     });
     resized.dispose();
-    return {segmentation, heatmapScores, offsets, padding};
+    return {
+      segmentation,
+      heatmapScores,
+      offsets,
+      padding,
+      internalResolutionHeightAndWidth
+    };
   }
 
   /**
@@ -460,7 +469,14 @@ export class BodyPix {
     config = {...PERSON_INFERENCE_CONFIG, ...config};
 
     validatePersonInferenceConfig(config);
-    const {segmentation, heatmapScores, offsets, padding} =
+
+    const {
+      segmentation,
+      heatmapScores,
+      offsets,
+      padding,
+      internalResolutionHeightAndWidth
+    } =
         this.segmentPersonActivation(
             input, config.internalResolution, config.segmentationThreshold);
 
@@ -473,8 +489,7 @@ export class BodyPix {
         heatmapScores, offsets, this.baseModel.outputStride);
 
     const resultPose = scaleAndFlipPoses(
-        [pose], [height, width],
-        [this.internalResolution, this.internalResolution], padding,
+        [pose], [height, width], internalResolutionHeightAndWidth, padding,
         config.flipHorizontal)[0];
 
     heatmapScores.dispose();
@@ -514,11 +529,12 @@ export class BodyPix {
     config = {...MULTI_PERSON_INSTANCE_INFERENCE_CONFIG, ...config};
     validateMultiPersonInstanceInferenceConfig(config);
     const [height, width] = getInputSize(input);
-    this.internalResolution =
-        toValidInternalResolutionNumber(config.internalResolution);
+    const internalResolutionHeightAndWidth = toInputResolutionHeightAndWidth(
+        config.internalResolution, this.baseModel.outputStride,
+        [height, width]);
 
-    const {resized, padding} = padAndResizeTo(
-        input, [this.internalResolution, this.internalResolution]);
+    const {resized, padding} =
+        padAndResizeTo(input, internalResolutionHeightAndWidth);
     const {
       segmentation,
       longOffsets,
@@ -536,16 +552,14 @@ export class BodyPix {
         displacementBwd,
       } = this.predictForMultiPersonInstanceSegmentationAndPart(resized);
       const scaledSegmentScores = scaleAndCropToInputTensorShape(
-          segmentLogits, [height, width],
-          [this.internalResolution, this.internalResolution],
+          segmentLogits, [height, width], internalResolutionHeightAndWidth,
           [[padding.top, padding.bottom], [padding.left, padding.right]],
           APPLY_SIGMOID_ACTIVATION);
       const longOffsetsResized = false;
       let scaledLongOffsets;
       if (longOffsetsResized) {
         scaledLongOffsets = scaleAndCropToInputTensorShape(
-            longOffsets, [height, width],
-            [this.internalResolution, this.internalResolution],
+            longOffsets, [height, width], internalResolutionHeightAndWidth,
             [[padding.top, padding.bottom], [padding.left, padding.right]],
             APPLY_SIGMOID_ACTIVATION);
       } else {
@@ -576,13 +590,12 @@ export class BodyPix {
         config.scoreThreshold, config.nmsRadius);
 
     poses = scaleAndFlipPoses(
-        poses, [height, width],
-        [this.internalResolution, this.internalResolution], padding, false);
+        poses, [height, width], internalResolutionHeightAndWidth, padding,
+        false);
 
     const instanceMasks = await decodePersonInstanceMasks(
         segmentation, longOffsets, poses, height, width,
-        this.baseModel.outputStride,
-        [this.internalResolution, this.internalResolution], padding,
+        this.baseModel.outputStride, internalResolutionHeightAndWidth, padding,
         config.scoreThreshold, config.refineSteps, config.minKeypointScore,
         config.maxDetections);
 
@@ -607,10 +620,12 @@ export class BodyPix {
    * @param input ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement)
    * The input image to feed through the network.
    *
-   * @param internalResolution`: Defaults to 'medium'. The internal resolution
-   * used by the model. The larger the internal resolution the more accurate the
-   * model at the cost of slower prediction times. Available values are 'low',
-   * 'medium', 'high' or a positive number.
+   * @param internalResolution Defaults to 'medium'. The internal resolution
+   * percentage that input is resized to before inference. The larger the
+   * internalResolution the more accurate the model at the cost of slower
+   * prediction times. Available values are 'low', 'medium', 'high', 'full', or
+   * a percentage value between 0 and 1. The values 'low', 'medium', 'high', and
+   * 'full' map to 0.25, 0.5, 0.75, and 1.0 correspondingly.
    *
    * @param segmentationThreshold The minimum that segmentation values must have
    * to be considered part of the person.  Affects the clipping of the colored
@@ -633,17 +648,16 @@ export class BodyPix {
     partSegmentation: tf.Tensor2D,
     heatmapScores: tf.Tensor3D,
     offsets: tf.Tensor3D,
-    padding: Padding
+    padding: Padding,
+    internalResolutionHeightAndWidth: [number, number]
   } {
     const [height, width] = getInputSize(input);
-    this.internalResolution =
-        toValidInternalResolutionNumber(internalResolution);
+    const internalResolutionHeightAndWidth = toInputResolutionHeightAndWidth(
+        internalResolution, this.baseModel.outputStride, [height, width]);
     const {
       resized,
       padding,
-    } =
-        padAndResizeTo(
-            input, [this.internalResolution, this.internalResolution]);
+    } = padAndResizeTo(input, internalResolutionHeightAndWidth);
 
     const {partSegmentation, heatmapScores, offsets} = tf.tidy(() => {
       const {segmentLogits, partHeatmapLogits, heatmapScores, offsets} =
@@ -670,7 +684,13 @@ export class BodyPix {
       };
     });
     resized.dispose();
-    return {partSegmentation, heatmapScores, offsets, padding};
+    return {
+      partSegmentation,
+      heatmapScores,
+      offsets,
+      padding,
+      internalResolutionHeightAndWidth
+    };
   }
 
   /**
@@ -706,7 +726,13 @@ export class BodyPix {
     config = {...PERSON_INFERENCE_CONFIG, ...config};
 
     validatePersonInferenceConfig(config);
-    const {partSegmentation, heatmapScores, offsets, padding} =
+    const {
+      partSegmentation,
+      heatmapScores,
+      offsets,
+      padding,
+      internalResolutionHeightAndWidth
+    } =
         this.segmentPersonPartsActivation(
             input, config.internalResolution, config.segmentationThreshold);
 
@@ -718,8 +744,7 @@ export class BodyPix {
         heatmapScores, offsets, this.baseModel.outputStride);
 
     const resultPose = scaleAndFlipPoses(
-        [pose], [height, width],
-        [this.internalResolution, this.internalResolution], padding,
+        [pose], [height, width], internalResolutionHeightAndWidth, padding,
         config.flipHorizontal)[0];
 
     heatmapScores.dispose();
@@ -759,10 +784,11 @@ export class BodyPix {
 
     validateMultiPersonInstanceInferenceConfig(config);
     const [height, width] = getInputSize(input);
-    this.internalResolution =
-        toValidInternalResolutionNumber(config.internalResolution);
-    const {resized, padding} = padAndResizeTo(
-        input, [this.internalResolution, this.internalResolution]);
+    const internalResolutionHeightAndWidth = toInputResolutionHeightAndWidth(
+        config.internalResolution, this.baseModel.outputStride,
+        [height, width]);
+    const {resized, padding} =
+        padAndResizeTo(input, internalResolutionHeightAndWidth);
     const {
       segmentation,
       longOffsets,
@@ -784,15 +810,13 @@ export class BodyPix {
 
       // decoding with scaling.
       const scaledSegmentScores = scaleAndCropToInputTensorShape(
-          segmentLogits, [height, width],
-          [this.internalResolution, this.internalResolution],
+          segmentLogits, [height, width], internalResolutionHeightAndWidth,
           [[padding.top, padding.bottom], [padding.left, padding.right]],
           APPLY_SIGMOID_ACTIVATION);
 
       // decoding with scaling.
       const scaledPartSegmentationScores = scaleAndCropToInputTensorShape(
-          partHeatmaps, [height, width],
-          [this.internalResolution, this.internalResolution],
+          partHeatmaps, [height, width], internalResolutionHeightAndWidth,
           [[padding.top, padding.bottom], [padding.left, padding.right]],
           APPLY_SIGMOID_ACTIVATION);
 
@@ -823,13 +847,12 @@ export class BodyPix {
         config.scoreThreshold, config.nmsRadius);
 
     poses = scaleAndFlipPoses(
-        poses, [height, width],
-        [this.internalResolution, this.internalResolution], padding, false);
+        poses, [height, width], internalResolutionHeightAndWidth, padding,
+        false);
 
     const instanceMasks = await decodePersonInstancePartMasks(
         segmentation, longOffsets, partSegmentation, poses, height, width,
-        this.baseModel.outputStride,
-        [this.internalResolution, this.internalResolution], padding,
+        this.baseModel.outputStride, internalResolutionHeightAndWidth, padding,
         config.scoreThreshold, config.refineSteps, config.minKeypointScore,
         config.maxDetections);
 

--- a/body-pix/src/types.ts
+++ b/body-pix/src/types.ts
@@ -1,6 +1,6 @@
 import * as tf from '@tensorflow/tfjs-core';
 
-export type BodyPixInternalResolution = number|'low'|'medium'|'high';
+export type BodyPixInternalResolution = number|'low'|'medium'|'high'|'full';
 export type BodyPixOutputStride = 32|16|8;
 export type BodyPixArchitecture = 'ResNet50'|'MobileNetV1';
 export type BodyPixQuantBytes = 1|2|4;


### PR DESCRIPTION
* adds option `full` for `internalResolution`, which maps to 1.00
* Gets rid of `this.internalResolution` on the BodyPixModel class and just setting local variables.