### PR TITLE
Update deeplab model urls

### DIFF
--- a/body-pix/package.json
+++ b/body-pix/package.json
@@ -13,12 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.1",
-    "@tensorflow/tfjs-converter": "~1.2.1"
+    "@tensorflow/tfjs-core": "^1.2.1",
+    "@tensorflow/tfjs-converter": "^1.2.1"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.1",
-    "@tensorflow/tfjs-converter": "~1.2.1",
+    "@tensorflow/tfjs-core": "^1.2.1",
+    "@tensorflow/tfjs-converter": "^1.2.1",
     "@types/jasmine": "~2.5.53",
     "jasmine": "~3.2.0",
     "jasmine-core": "~3.1.0",

--- a/coco-ssd/package.json
+++ b/coco-ssd/package.json
@@ -13,12 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.6",
-    "@tensorflow/tfjs-converter": "~1.2.5"
+    "@tensorflow/tfjs-core": "^1.2.6",
+    "@tensorflow/tfjs-converter": "^1.2.5"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.6",
-    "@tensorflow/tfjs-converter": "~1.2.5",
+    "@tensorflow/tfjs-core": "^1.2.6",
+    "@tensorflow/tfjs-converter": "^1.2.5",
     "@types/jasmine": "~2.8.8",
     "babel-core": "~6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",

--- a/deeplab/README.md
+++ b/deeplab/README.md
@@ -1,7 +1,5 @@
 # Semantic Segmentation in the Browser: DeepLab v3 Model
 
-## This model is a work-in-progress and has not been released yet. We will update this README when the model is released and usable
-
 This package contains a standalone implementation of the DeepLab inference pipeline, as well as a [demo](./demo), for running semantic segmentation using TensorFlow.js.
 
 ![DeepLab Demo](./docs/deeplab-demo.gif)
@@ -16,8 +14,7 @@ To get started, pick the model name from `pascal`, `cityscapes` and `ade20k`, an
 import * as tf from '@tensorflow-models/tfjs';
 import * as deeplab from '@tensorflow-models/deeplab';
 const loadModel = async () => {
-  const modelName = 'pascal';   // set to your preferred model, out of `pascal`,
-                                // `cityscapes` and `ade20k`
+  const modelName = 'pascal';   // set to your preferred model, either `pascal`, `cityscapes` or `ade20k`
   const quantizationBytes = 2;  // either 1, 2 or 4
   return await deeplab.load({base: modelName, quantizationBytes});
 };
@@ -39,8 +36,7 @@ If you would rather load custom weights, you can pass the URL in the config inst
 ```typescript
 import * as deeplab from '@tensorflow-models/deeplab';
 const loadModel = async () => {
-  // #TODO(tfjs): Replace this URL after you host the model
-  const url = 'https://storage.googleapis.com/gsoc-tfjs/models/deeplab/quantized/1/pascal/model.json';
+  const url = 'https://example.com/models/deeplab-custom-weights/model.json';
   return await deeplab.load({modelUrl: url});
 };
 loadModel().then(() => console.log(`Loaded the model successfully!`));

--- a/deeplab/README.md
+++ b/deeplab/README.md
@@ -36,7 +36,7 @@ If you would rather load custom weights, you can pass the URL in the config inst
 ```typescript
 import * as deeplab from '@tensorflow-models/deeplab';
 const loadModel = async () => {
-  const url = 'https://example.com/models/deeplab-custom-weights/model.json';
+  const url = 'https://tfhub.dev/tensorflow/tfjs-model/deeplab/pascal/1/default/1/model.json?tfjs-format=file';
   return await deeplab.load({modelUrl: url});
 };
 loadModel().then(() => console.log(`Loaded the model successfully!`));

--- a/deeplab/demo/package.json
+++ b/deeplab/demo/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@tensorflow-models/deeplab": "link:.yalc/@tensorflow-models/deeplab",
-    "@tensorflow/tfjs-converter": "1.2.5",
-    "@tensorflow/tfjs-core": "1.2.5",
+    "@tensorflow/tfjs-converter": "1.3.1",
+    "@tensorflow/tfjs-core": "1.3.1",
     "bulma": "^0.7.5"
   },
   "scripts": {

--- a/deeplab/demo/src/index.html
+++ b/deeplab/demo/src/index.html
@@ -54,8 +54,8 @@ limitations under the License.
                         </div>
                       </div>
                       <footer class="card-footer">
-                        <a class="button card-footer-item is-unselectable" id="toggle-pascal-image">Toggle
-                          example</a>
+                        <a class="button card-footer-item is-unselectable" id="toggle-pascal-image">Load
+                          example image</a>
                         <a class="button card-footer-item is-unselectable" id="run-pascal">Run</a>
                       </footer>
                     </div>
@@ -72,16 +72,10 @@ limitations under the License.
                         </div>
                       </div>
                       <footer class="card-footer">
-                        <a class="button card-footer-item is-unselectable" id="toggle-cityscapes-image">Toggle
-                          example</a>
+                        <a class="button card-footer-item is-unselectable" id="toggle-cityscapes-image">Load
+                          example image</a>
                         <a class="button card-footer-item is-unselectable" id="run-cityscapes">Run</a>
                       </footer>
-                    </div>
-                    <div class="notification is-danger has-text-weight-semibold is-size-7 is-paddingless">
-                      <span class="is-concise-message">
-                        Running this model is resource-intensive and might
-                        crash your browser.
-                      </span>
                     </div>
                   </div>
                   <div class="column">
@@ -96,8 +90,8 @@ limitations under the License.
                         </div>
                       </div>
                       <footer class="card-footer">
-                        <a class="button card-footer-item is-unselectable" id="toggle-ade20k-image">Toggle
-                          example</a>
+                        <a class="button card-footer-item is-unselectable" id="toggle-ade20k-image">Load
+                          example image</a>
                         <a class="button card-footer-item is-unselectable" id="run-ade20k">Run</a>
                       </footer>
                     </div>

--- a/deeplab/package.json
+++ b/deeplab/package.json
@@ -17,8 +17,8 @@
     "@tensorflow/tfjs-core": "^1.2.5"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-converter": "1.3.1",
-    "@tensorflow/tfjs-core": "1.3.1",
+    "@tensorflow/tfjs-converter": "^1.3.1",
+    "@tensorflow/tfjs-core": "^1.3.1",
     "@types/jasmine": "~3.3.15",
     "canvas": "^2.5.0",
     "clang-format": "^1.2.4",

--- a/deeplab/package.json
+++ b/deeplab/package.json
@@ -13,12 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-converter": "1.2.5",
-    "@tensorflow/tfjs-core": "1.2.5"
+    "@tensorflow/tfjs-converter": "^1.2.5",
+    "@tensorflow/tfjs-core": "^1.2.5"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-converter": "1.2.5",
-    "@tensorflow/tfjs-core": "1.2.5",
+    "@tensorflow/tfjs-converter": "1.3.1",
+    "@tensorflow/tfjs-core": "1.3.1",
     "@types/jasmine": "~3.3.15",
     "canvas": "^2.5.0",
     "clang-format": "^1.2.4",

--- a/deeplab/src/config.ts
+++ b/deeplab/src/config.ts
@@ -16,8 +16,7 @@
  */
 
 export const config = {
-  // #TODO(tfjs): Replace this URL after you host the model
-  BASE_PATH: 'https://storage.googleapis.com/gsoc-tfjs/models/deeplab',
+  BASE_PATH: 'https://tfhub.dev/tensorflow/tfjs-model/deeplab',
   CROP_SIZE: 513,
   COLORMAPS: {
     ADE20K: [

--- a/deeplab/src/deeplab_test.ts
+++ b/deeplab/src/deeplab_test.ts
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 import * as tf from '@tensorflow/tfjs-core';
+// tslint:disable-next-line: no-imports-from-dist
 import {describeWithFlags, NODE_ENVS,} from '@tensorflow/tfjs-core/dist/jasmine_util';
 import {createCanvas} from 'canvas';
 import {load} from '.';
@@ -22,7 +23,7 @@ import {load} from '.';
 describeWithFlags('SemanticSegmentation', NODE_ENVS, () => {
   it('SemanticSegmentation should not leak', async () => {
     const model = await load();
-    const x = tf.zeros([227, 500, 3]) as tf.Tensor3D;
+    const x: tf.Tensor3D = tf.zeros([227, 500, 3]);
     const numOfTensorsBefore = tf.memory().numTensors;
 
     await model.segment(x);
@@ -30,7 +31,7 @@ describeWithFlags('SemanticSegmentation', NODE_ENVS, () => {
   });
 
   it('SemanticSegmentation map has matching dimensions', async () => {
-    const x = tf.zeros([513, 500, 3]) as tf.Tensor3D;
+    const x: tf.Tensor3D = tf.zeros([513, 500, 3]);
     const model = await load();
     const segmentationMapTensor = await model.predict(x);
     const [height, width] = segmentationMapTensor.shape;
@@ -39,7 +40,7 @@ describeWithFlags('SemanticSegmentation', NODE_ENVS, () => {
 
   it('SemanticSegmentation segment method generates valid output', async () => {
     const model = await load();
-    const x = tf.zeros([300, 500, 3]) as tf.Tensor3D;
+    const x: tf.Tensor3D = tf.zeros([300, 500, 3]);
 
     const {legend} = await model.segment(x);
     expect(Object.keys(legend)).toContain('background');

--- a/deeplab/src/index.ts
+++ b/deeplab/src/index.ts
@@ -83,8 +83,10 @@ export async function load(
         `together with the degree of quantization (either 1, 2 or 4).` +
         `Aborting, since neither has been provided.`);
   }
-  const url = getURL(modelConfig.base, modelConfig.quantizationBytes);
-  const graphModel = await tfconv.loadGraphModel(modelConfig.modelUrl || url);
+
+  const graphModel = await tfconv.loadGraphModel(
+      modelConfig.modelUrl ||
+      getURL(modelConfig.base, modelConfig.quantizationBytes));
   const deeplab = new SemanticSegmentation(graphModel, modelConfig.base);
   return deeplab;
 }

--- a/deeplab/src/utils.ts
+++ b/deeplab/src/utils.ts
@@ -57,16 +57,20 @@ export function createPascalColormap(): Color[] {
  * float32 compressed to 1 or 2 bytes respectively.
  * Set it to 4 to disable quantization.
  *
- * @return The URL of the TF.js GraphModel weights
+ * @return The URL of the TF.js model
  */
 export function getURL(
-    base: ModelArchitecture,
-    quantizationBytes: QuantizationBytes,
-) {
-  return `${config['BASE_PATH']}/${
-      ([1, 2].indexOf(quantizationBytes) !== -1) ?
-          `quantized/${quantizationBytes}/` :
-          ''}${base}/model.json`;
+    base: ModelArchitecture, quantizationBytes: QuantizationBytes) {
+  const TFHUB_BASE = `${config['BASE_PATH']}`;
+  const TFHUB_QUERY_PARAM = 'tfjs-format=file';
+
+  const modelPath = quantizationBytes === 4 ?
+      `${base}/1/default/1/model.json` :
+      `${base}/1/quantized/${quantizationBytes}/1/model.json`;
+
+  // Example of url that should be generated/
+  // https://tfhub.dev/tensorflow/tfjs-model/deeplab/pascal/1/default/1/model.json?tfjs-format=file
+  return `${TFHUB_BASE}/${modelPath}?${TFHUB_QUERY_PARAM}`;
 }
 
 /**

--- a/deeplab/src/utils.ts
+++ b/deeplab/src/utils.ts
@@ -68,7 +68,7 @@ export function getURL(
       `${base}/1/default/1/model.json` :
       `${base}/1/quantized/${quantizationBytes}/1/model.json`;
 
-  // Example of url that should be generated/
+  // Example of url that should be generated.
   // https://tfhub.dev/tensorflow/tfjs-model/deeplab/pascal/1/default/1/model.json?tfjs-format=file
   return `${TFHUB_BASE}/${modelPath}?${TFHUB_QUERY_PARAM}`;
 }

--- a/deeplab/yarn.lock
+++ b/deeplab/yarn.lock
@@ -18,15 +18,15 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@tensorflow/tfjs-converter@1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.5.tgz#11b10a421605f82eb7c8da2bfb42bd8ccfc35303"
-  integrity sha512-KQoNDl1UDmBBqknaxiFg2tyYoVFyxJ0q5mY/e6mqavokf4vVXn4TsurzxDx++uV6gKEL1fPk9TuSIaq8xHuCRQ==
+"@tensorflow/tfjs-converter@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.3.1.tgz#4e08e07621f43690a0b69c345cd63bc1f6974879"
+  integrity sha512-8IHzcIZwqCofcRBhaCTN6W73m2RGdBDH6BEORf0KDdbgbz4DouItVcKX692PrA8gchY+Xy8ZHMpj93PcAOs17g==
 
-"@tensorflow/tfjs-core@1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.5.tgz#865f0b3d7a79614650698c907185dd0adfb6470e"
-  integrity sha512-2M88UcKVfcMwtIaDEOJKWAxgX9rO+UdPnRZGSyWW/vH2PiB+jKtB6//7O5V4JpbRjA2ZJFjhfQ5ybfQf8wawRg==
+"@tensorflow/tfjs-core@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.3.1.tgz#89e3253f320233120ee24d4ae62fca65c315580f"
+  integrity sha512-X4MKhpg1gLEZetKUMeQNW6diP3gbFFddeF6UT816sH8jOenX/8x2HnVmANpNnUxCTPhDniY3V9zhBWwbl13+Yg==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"

--- a/knn-classifier/package.json
+++ b/knn-classifier/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.1"
+    "@tensorflow/tfjs-core": "^1.2.1"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.1",
+    "@tensorflow/tfjs-core": "^1.2.1",
     "@types/jasmine": "~2.5.53",
     "babel-core": "~6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",

--- a/mobilenet/package.json
+++ b/mobilenet/package.json
@@ -13,12 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.1",
-    "@tensorflow/tfjs-converter": "~1.2.1"
+    "@tensorflow/tfjs-core": "^1.2.1",
+    "@tensorflow/tfjs-converter": "^1.2.1"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.1",
-    "@tensorflow/tfjs-converter": "~1.2.1",
+    "@tensorflow/tfjs-core": "^1.2.1",
+    "@tensorflow/tfjs-converter": "^1.2.1",
     "@types/jasmine": "~2.5.53",
     "babel-core": "^6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clang-format": "~1.2.2",
     "fs": "~0.0.1-security",
     "jasmine": "~3.1.0",
+    "semver": "^6.3.0",
     "shelljs": "0.8.2",
     "ts-node": "~5.0.0",
     "tslint": "~5.18.0",

--- a/posenet/package.json
+++ b/posenet/package.json
@@ -13,12 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~1.3.0",
-    "@tensorflow/tfjs-converter": "~1.3.0"
+    "@tensorflow/tfjs-core": "^1.3.0",
+    "@tensorflow/tfjs-converter": "^1.3.0"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~1.3.0",
-    "@tensorflow/tfjs-converter": "~1.3.0",
+    "@tensorflow/tfjs-core": "^1.3.0",
+    "@tensorflow/tfjs-converter": "^1.3.0",
     "@types/jasmine": "~2.5.53",
     "babel-core": "^6.26.0",
     "babel-plugin-transform-runtime": "~6.23.0",

--- a/presubmit.ts
+++ b/presubmit.ts
@@ -48,23 +48,12 @@ function assertPeerDepSatisfied(peerDeps, devDeps, dependencyName, dir) {
   }
 }
 
-function assertCaretPeerDep(peerDeps, dependencyName, dir) {
-  const peerDep = peerDeps[dependencyName];
-  if (peerDep != null) {
-    if (!peerDep.startsWith('^')) {
+function assertCaretDep(depsMap, dependencyName, dir, depType) {
+  const dep = depsMap[dependencyName];
+  if (dep != null) {
+    if (!dep.startsWith('^')) {
       throw new Error(
-          `peerDependency version (${peerDep}) of ${dependencyName} for ` +
-          `${dir} must start with ^.`);
-    }
-  }
-}
-
-function assertCaretDevDep(devDeps, dependencyName, dir) {
-  const devDep = devDeps[dependencyName];
-  if (devDep != null) {
-    if (!devDep.startsWith('^')) {
-      throw new Error(
-          `devDependency version (${devDep}) of ${dependencyName} for ` +
+          `${depType} version (${dep}) of ${dependencyName} for ` +
           `${dir} must start with ^.`);
     }
   }
@@ -85,13 +74,13 @@ dirs.forEach(dir => {
   const peerDeps = pkg.peerDependencies;
   const devDeps = pkg.devDependencies;
 
-  assertCaretPeerDep(peerDeps, '@tensorflow/tfjs', dir);
-  assertCaretPeerDep(peerDeps, '@tensorflow/tfjs-core', dir);
-  assertCaretPeerDep(peerDeps, '@tensorflow/tfjs-converter', dir);
+  assertCaretDep(peerDeps, '@tensorflow/tfjs', dir, 'peerDep');
+  assertCaretDep(peerDeps, '@tensorflow/tfjs-core', dir, 'peerDep');
+  assertCaretDep(peerDeps, '@tensorflow/tfjs-converter', dir, 'peerDep');
 
-  assertCaretDevDep(devDeps, '@tensorflow/tfjs', dir);
-  assertCaretDevDep(devDeps, '@tensorflow/tfjs-core', dir);
-  assertCaretDevDep(devDeps, '@tensorflow/tfjs-converter', dir);
+  assertCaretDep(devDeps, '@tensorflow/tfjs', dir, 'devDep');
+  assertCaretDep(devDeps, '@tensorflow/tfjs-core', dir, 'devDep');
+  assertCaretDep(devDeps, '@tensorflow/tfjs-converter', dir, 'devDep');
 
   assertPeerDepSatisfied(peerDeps, devDeps, '@tensorflow/tfjs', dir);
   assertPeerDepSatisfied(peerDeps, devDeps, '@tensorflow/tfjs-core', dir);

--- a/presubmit.ts
+++ b/presubmit.ts
@@ -85,9 +85,9 @@ dirs.forEach(dir => {
   const peerDeps = pkg.peerDependencies;
   const devDeps = pkg.devDependencies;
 
-  assertCaretDevDep(peerDeps, '@tensorflow/tfjs', dir);
-  assertCaretDevDep(peerDeps, '@tensorflow/tfjs-core', dir);
-  assertCaretDevDep(peerDeps, '@tensorflow/tfjs-converter', dir);
+  assertCaretPeerDep(peerDeps, '@tensorflow/tfjs', dir);
+  assertCaretPeerDep(peerDeps, '@tensorflow/tfjs-core', dir);
+  assertCaretPeerDep(peerDeps, '@tensorflow/tfjs-converter', dir);
 
   assertCaretDevDep(devDeps, '@tensorflow/tfjs', dir);
   assertCaretDevDep(devDeps, '@tensorflow/tfjs-core', dir);

--- a/toxicity/package.json
+++ b/toxicity/package.json
@@ -13,15 +13,15 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.9",
-    "@tensorflow/tfjs-converter": "~1.2.9"
+    "@tensorflow/tfjs-core": "^1.2.9",
+    "@tensorflow/tfjs-converter": "^1.2.9"
   },
   "dependencies": {
     "@tensorflow-models/universal-sentence-encoder": "~1.2.0"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.9",
-    "@tensorflow/tfjs-converter": "~1.2.9",
+    "@tensorflow/tfjs-core": "^1.2.9",
+    "@tensorflow/tfjs-converter": "^1.2.9",
     "@types/jasmine": "~2.5.53",
     "babel-core": "^6.26.3",
     "jasmine": "^3.3.1",

--- a/universal-sentence-encoder/package.json
+++ b/universal-sentence-encoder/package.json
@@ -13,12 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.9",
-    "@tensorflow/tfjs-converter": "~1.2.9"
+    "@tensorflow/tfjs-core": "^1.2.9",
+    "@tensorflow/tfjs-converter": "^1.2.9"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "~1.2.9",
-    "@tensorflow/tfjs-converter": "~1.2.9",
+    "@tensorflow/tfjs-core": "^1.2.9",
+    "@tensorflow/tfjs-converter": "^1.2.9",
     "@types/jasmine": "~2.5.53",
     "jasmine": "^3.3.1",
     "jasmine-core": "^3.3.0",


### PR DESCRIPTION
Updates the deeplab model urls to point to new tfhub hosted assets. 

Also cleans up some warnings to match new tslint settings.

Note after this PR lands:
 - We will publish deeplab package to NPM (version is currently 0.1.0)
 - Make a followup PR updating the package.json in the deeplab demo to point to newly published package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/342)
<!-- Reviewable:end -->
