### PR TITLE
PoseNet - remove partChannels which are only used in BodyPix

### DIFF
--- a/posenet/src/keypoints.ts
+++ b/posenet/src/keypoints.ts
@@ -65,30 +65,3 @@ export const poseChain: StringTuple[] = [
 
 export const connectedPartIndices = connectedPartNames.map(
     ([jointNameA, jointNameB]) => ([partIds[jointNameA], partIds[jointNameB]]));
-
-export const partChannels: string[] = [
-  'left_face',
-  'right_face',
-  'right_upper_leg_front',
-  'right_lower_leg_back',
-  'right_upper_leg_back',
-  'left_lower_leg_front',
-  'left_upper_leg_front',
-  'left_upper_leg_back',
-  'left_lower_leg_back',
-  'right_feet',
-  'right_lower_leg_front',
-  'left_feet',
-  'torso_front',
-  'torso_back',
-  'right_upper_arm_front',
-  'right_upper_arm_back',
-  'right_lower_arm_back',
-  'left_lower_arm_front',
-  'left_upper_arm_front',
-  'left_upper_arm_back',
-  'left_lower_arm_back',
-  'right_hand',
-  'right_lower_arm_front',
-  'left_hand'
-];


### PR DESCRIPTION
remove the partChannels constant from PoseNet, which is not used in PoseNet and was accidentally added there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/348)
<!-- Reviewable:end -->
