### PR TITLE
Fix datasets urls in deeplab README

### DIFF
--- a/deeplab/README.md
+++ b/deeplab/README.md
@@ -80,9 +80,9 @@ The `segment` method of the `SemanticSegmentation` object covers most use cases.
 
 Each model recognises a different set of object classes in an image:
 
-- [PASCAL](./deeplab/src/config.ts#L60)
-- [CityScapes](./deeplab/src/config.ts#L66)
-- [ADE20K](./deeplab/src/config.ts#L72)
+- [PASCAL](./src/config.ts#L142)
+- [CityScapes](./src/config.ts#L149)
+- [ADE20K](./src/config.ts#L155)
 
 #### `model.segment(image, config?)` inputs
 


### PR DESCRIPTION
1. Fixes the relative urls (path starts from the current directory instead of root)
2. Changes the lines number to jump to labels instead of color maps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/349)
<!-- Reviewable:end -->
