### PR TITLE
marks flipHorizontal, internalResolution, segmentationThreshold optional

### DIFF
--- a/body-pix/src/body_pix_model.ts
+++ b/body-pix/src/body_pix_model.ts
@@ -101,7 +101,7 @@ const VALID_MULTIPLIER: {[id: string]: BodyPixMultiplier[]} = {
 };
 const VALID_QUANT_BYTES: BodyPixQuantBytes[] = [1, 2, 4];
 
-function validateModelConfig(config: ModelConfig) {
+function validateModelConfig(config: ModelConfig): ModelConfig {
   config = config || MOBILENET_V1_CONFIG;
 
   if (config.architecture == null) {
@@ -170,9 +170,9 @@ function validateModelConfig(config: ModelConfig) {
  *
  */
 export interface InferenceConfig {
-  flipHorizontal: boolean;
-  internalResolution: BodyPixInternalResolution;
-  segmentationThreshold: number;
+  flipHorizontal?: boolean;
+  internalResolution?: BodyPixInternalResolution;
+  segmentationThreshold?: number;
 }
 
 /**
@@ -246,23 +246,48 @@ export const MULTI_PERSON_INSTANCE_INFERENCE_CONFIG:
     };
 
 function validatePersonInferenceConfig(config: PersonInferenceConfig) {
-  const segmentationThreshold = config.segmentationThreshold;
+  const {segmentationThreshold, maxDetections, scoreThreshold, nmsRadius} =
+      config;
+
   if (segmentationThreshold < 0.0 || segmentationThreshold > 1.0) {
     throw new Error(
         `segmentationThreshold ${segmentationThreshold}. ` +
         `Should be in range [0.0, 1.0]`);
+  }
+
+  if (maxDetections <= 0) {
+    throw new Error(
+        `Invalid maxDetections ${maxDetections}. ` +
+        `Should be > 0`);
+  }
+
+  if (scoreThreshold < 0.0 || scoreThreshold > 1.0) {
+    throw new Error(
+        `Invalid scoreThreshold ${scoreThreshold}. ` +
+        `Should be in range [0.0, 1.0]`);
+  }
+
+  if (nmsRadius <= 0) {
+    throw new Error(`Invalid nmsRadius ${nmsRadius}.`);
   }
 }
 
 function validateMultiPersonInstanceInferenceConfig(
     config: MultiPersonInstanceInferenceConfig) {
   const {
+    segmentationThreshold,
     maxDetections,
     scoreThreshold,
     nmsRadius,
     minKeypointScore,
     refineSteps
   } = config;
+
+  if (segmentationThreshold < 0.0 || segmentationThreshold > 1.0) {
+    throw new Error(
+        `segmentationThreshold ${segmentationThreshold}. ` +
+        `Should be in range [0.0, 1.0]`);
+  }
 
   if (maxDetections <= 0) {
     throw new Error(
@@ -286,7 +311,7 @@ function validateMultiPersonInstanceInferenceConfig(
         `Should be in range [0.0, 1.0]`);
   }
 
-  if (refineSteps <= 0 || minKeypointScore > 20) {
+  if (refineSteps <= 0 || refineSteps > 20) {
     throw new Error(
         `Invalid refineSteps ${refineSteps}.` +
         `Should be in range [1, 20]`);

--- a/body-pix/src/body_pix_test.ts
+++ b/body-pix/src/body_pix_test.ts
@@ -105,35 +105,39 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
     expect(tf.memory().numTensors).toEqual(beforeTensors);
   });
 
-  it('segmentPerson handles null in InferenceConfig', async () => {
-    const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
-    spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
-    await bodyPix.segmentPerson(input, {});
-    expect(util.toInputResolutionHeightAndWidth)
-        .toHaveBeenCalledWith('medium', 32, [73, 73]);
-  });
+  it('segmentPerson uses default values when null is passed in inferenceConfig parameters',
+     async () => {
+       const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
+       spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
+       await bodyPix.segmentPerson(input, {});
+       expect(util.toInputResolutionHeightAndWidth)
+           .toHaveBeenCalledWith('medium', 32, [73, 73]);
+     });
 
-  it('segmentMultiPerson handles null in InferenceConfig', async () => {
-    const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
-    spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
-    await bodyPix.segmentMultiPerson(input, {});
-    expect(util.toInputResolutionHeightAndWidth)
-        .toHaveBeenCalledWith('medium', 32, [73, 73]);
-  });
+  it('segmentMultiPerson uses default values when null is passed in inferenceConfig parameters',
+     async () => {
+       const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
+       spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
+       await bodyPix.segmentMultiPerson(input, {});
+       expect(util.toInputResolutionHeightAndWidth)
+           .toHaveBeenCalledWith('medium', 32, [73, 73]);
+     });
 
-  it('segmentPersonParts handles null in InferenceConfig', async () => {
-    const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
-    spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
-    await bodyPix.segmentPersonParts(input, {});
-    expect(util.toInputResolutionHeightAndWidth)
-        .toHaveBeenCalledWith('medium', 32, [73, 73]);
-  });
+  it('segmentPersonParts uses default values when null is passed in inferenceConfig parameters',
+     async () => {
+       const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
+       spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
+       await bodyPix.segmentPersonParts(input, {});
+       expect(util.toInputResolutionHeightAndWidth)
+           .toHaveBeenCalledWith('medium', 32, [73, 73]);
+     });
 
-  it('segmentMultiPersonParts handles null in InferenceConfig', async () => {
-    const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
-    spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
-    await bodyPix.segmentMultiPersonParts(input, {});
-    expect(util.toInputResolutionHeightAndWidth)
-        .toHaveBeenCalledWith('medium', 32, [73, 73]);
-  });
+  it('segmentMultiPersonParts uses default values when null is passed in inferenceConfig parameters',
+     async () => {
+       const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
+       spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
+       await bodyPix.segmentMultiPersonParts(input, {});
+       expect(util.toInputResolutionHeightAndWidth)
+           .toHaveBeenCalledWith('medium', 32, [73, 73]);
+     });
 });

--- a/body-pix/src/body_pix_test.ts
+++ b/body-pix/src/body_pix_test.ts
@@ -105,7 +105,8 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
     expect(tf.memory().numTensors).toEqual(beforeTensors);
   });
 
-  it('segmentPerson uses default values when null is passed in inferenceConfig parameters',
+  it(`segmentPerson uses default values when null is
+      passed in inferenceConfig parameters`,
      async () => {
        const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
        spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
@@ -114,7 +115,8 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
            .toHaveBeenCalledWith('medium', 32, [73, 73]);
      });
 
-  it('segmentMultiPerson uses default values when null is passed in inferenceConfig parameters',
+  it(`segmentMultiPerson uses default values when null is
+      passed in inferenceConfig parameters`,
      async () => {
        const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
        spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
@@ -123,7 +125,8 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
            .toHaveBeenCalledWith('medium', 32, [73, 73]);
      });
 
-  it('segmentPersonParts uses default values when null is passed in inferenceConfig parameters',
+  it(`segmentPersonParts uses default values when null is
+      passed in inferenceConfig parameters`,
      async () => {
        const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
        spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
@@ -132,7 +135,8 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
            .toHaveBeenCalledWith('medium', 32, [73, 73]);
      });
 
-  it('segmentMultiPersonParts uses default values when null is passed in inferenceConfig parameters',
+  it(`segmentMultiPersonParts uses default values when null is
+      passed in inferenceConfig parameters`,
      async () => {
        const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
        spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();

--- a/body-pix/src/body_pix_test.ts
+++ b/body-pix/src/body_pix_test.ts
@@ -105,8 +105,8 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
     expect(tf.memory().numTensors).toEqual(beforeTensors);
   });
 
-  it(`segmentPerson uses default values when null is
-      passed in inferenceConfig parameters`,
+  it(`segmentPerson uses default values when null is ` +
+         `passed in inferenceConfig parameters`,
      async () => {
        const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
        spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
@@ -115,8 +115,8 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
            .toHaveBeenCalledWith('medium', 32, [73, 73]);
      });
 
-  it(`segmentMultiPerson uses default values when null is
-      passed in inferenceConfig parameters`,
+  it(`segmentMultiPerson uses default values when null is ` +
+         `passed in inferenceConfig parameters`,
      async () => {
        const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
        spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
@@ -125,8 +125,8 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
            .toHaveBeenCalledWith('medium', 32, [73, 73]);
      });
 
-  it(`segmentPersonParts uses default values when null is
-      passed in inferenceConfig parameters`,
+  it(`segmentPersonParts uses default values when null is ` +
+         `passed in inferenceConfig parameters`,
      async () => {
        const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
        spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
@@ -135,8 +135,8 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
            .toHaveBeenCalledWith('medium', 32, [73, 73]);
      });
 
-  it(`segmentMultiPersonParts uses default values when null is
-      passed in inferenceConfig parameters`,
+  it(`segmentMultiPersonParts uses default values when null is ` +
+         `passed in inferenceConfig parameters`,
      async () => {
        const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
        spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();

--- a/body-pix/src/body_pix_test.ts
+++ b/body-pix/src/body_pix_test.ts
@@ -103,4 +103,36 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
     await bodyPix.segmentMultiPersonParts(input);
     expect(tf.memory().numTensors).toEqual(beforeTensors);
   });
+
+  it('segmentPerson handles null in InferenceConfig', async () => {
+    const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
+
+    const beforeTensors = tf.memory().numTensors;
+
+    await bodyPix.segmentPerson(input, {});
+    expect(tf.memory().numTensors).toEqual(beforeTensors);
+  });
+
+  it('segmentMultiPerson handles null in InferenceConfig', async () => {
+    const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
+
+    const beforeTensors = tf.memory().numTensors;
+
+    await bodyPix.segmentMultiPerson(input, {});
+    expect(tf.memory().numTensors).toEqual(beforeTensors);
+  });
+
+  it('segmentPersonParts handles null in InferenceConfig', async () => {
+    const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
+    const beforeTensors = tf.memory().numTensors;
+    await bodyPix.segmentPersonParts(input, {});
+    expect(tf.memory().numTensors).toEqual(beforeTensors);
+  });
+
+  it('segmentMultiPersonParts handles null in InferenceConfig', async () => {
+    const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
+    const beforeTensors = tf.memory().numTensors;
+    await bodyPix.segmentMultiPersonParts(input, {});
+    expect(tf.memory().numTensors).toEqual(beforeTensors);
+  });
 });

--- a/body-pix/src/body_pix_test.ts
+++ b/body-pix/src/body_pix_test.ts
@@ -23,6 +23,7 @@ import {ALL_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_ut
 
 import * as bodyPixModel from './body_pix_model';
 import * as resnet from './resnet';
+import * as util from './util';
 
 describeWithFlags('BodyPix', ALL_ENVS, () => {
   let bodyPix: bodyPixModel.BodyPix;
@@ -106,33 +107,33 @@ describeWithFlags('BodyPix', ALL_ENVS, () => {
 
   it('segmentPerson handles null in InferenceConfig', async () => {
     const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
-
-    const beforeTensors = tf.memory().numTensors;
-
+    spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
     await bodyPix.segmentPerson(input, {});
-    expect(tf.memory().numTensors).toEqual(beforeTensors);
+    expect(util.toInputResolutionHeightAndWidth)
+        .toHaveBeenCalledWith('medium', 32, [73, 73]);
   });
 
   it('segmentMultiPerson handles null in InferenceConfig', async () => {
     const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
-
-    const beforeTensors = tf.memory().numTensors;
-
+    spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
     await bodyPix.segmentMultiPerson(input, {});
-    expect(tf.memory().numTensors).toEqual(beforeTensors);
+    expect(util.toInputResolutionHeightAndWidth)
+        .toHaveBeenCalledWith('medium', 32, [73, 73]);
   });
 
   it('segmentPersonParts handles null in InferenceConfig', async () => {
     const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
-    const beforeTensors = tf.memory().numTensors;
+    spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
     await bodyPix.segmentPersonParts(input, {});
-    expect(tf.memory().numTensors).toEqual(beforeTensors);
+    expect(util.toInputResolutionHeightAndWidth)
+        .toHaveBeenCalledWith('medium', 32, [73, 73]);
   });
 
   it('segmentMultiPersonParts handles null in InferenceConfig', async () => {
     const input: tf.Tensor3D = tf.zeros([73, 73, 3]);
-    const beforeTensors = tf.memory().numTensors;
+    spyOn(util, 'toInputResolutionHeightAndWidth').and.callThrough();
     await bodyPix.segmentMultiPersonParts(input, {});
-    expect(tf.memory().numTensors).toEqual(beforeTensors);
+    expect(util.toInputResolutionHeightAndWidth)
+        .toHaveBeenCalledWith('medium', 32, [73, 73]);
   });
 });


### PR DESCRIPTION
To support invoking .segmentPerson,MultiPerson,PersonParts,MultiPersonParts with an {} InferenceConfig, this PR marks the following fields in InferenceConfig optional:
* flipHorizontal
* internalResolution
* segmentationThreshold

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/351)
<!-- Reviewable:end -->
