### PR TITLE
[BodyPix] remove unused parameter in demo

### DIFF
--- a/body-pix/demos/index.js
+++ b/body-pix/demos/index.js
@@ -179,7 +179,6 @@ const guiState = {
     maxDetections: 5,
     scoreThreshold: 0.3,
     nmsRadius: 20,
-    numKeypointForMatching: 17,
     refineSteps: 10
   },
   segmentation: {
@@ -378,8 +377,6 @@ function setupGui(cameras) {
       guiState.multiPersonDecoding, 'scoreThreshold', 0.0, 1.0);
   multiPersonDecoding.add(guiState.multiPersonDecoding, 'nmsRadius', 0, 30, 1);
   multiPersonDecoding.add(
-      guiState.multiPersonDecoding, 'numKeypointForMatching', 1, 17, 1);
-  multiPersonDecoding.add(
       guiState.multiPersonDecoding, 'refineSteps', 1, 10, 1);
   multiPersonDecoding.open();
 
@@ -524,8 +521,6 @@ async function estimateSegmentation() {
         maxDetections: guiState.multiPersonDecoding.maxDetections,
         scoreThreshold: guiState.multiPersonDecoding.scoreThreshold,
         nmsRadius: guiState.multiPersonDecoding.nmsRadius,
-        numKeypointForMatching:
-            guiState.multiPersonDecoding.numKeypointForMatching,
         refineSteps: guiState.multiPersonDecoding.refineSteps
       });
     case 'person':
@@ -551,8 +546,6 @@ async function estimatePartSegmentation() {
         maxDetections: guiState.multiPersonDecoding.maxDetections,
         scoreThreshold: guiState.multiPersonDecoding.scoreThreshold,
         nmsRadius: guiState.multiPersonDecoding.nmsRadius,
-        numKeypointForMatching:
-            guiState.multiPersonDecoding.numKeypointForMatching,
         refineSteps: guiState.multiPersonDecoding.refineSteps
       });
     case 'person':


### PR DESCRIPTION
As far as I can tell, `numKeypointForMatching` isn't part of the current BodyPix model / doesn't do anything.

(you can verifying this by searching the repo for `numKeypointForMatching`—the only hits are in the demo)