### PR TITLE
Actually use TFHub for USE and toxicity models.

### DIFF
--- a/toxicity/demo/package.json
+++ b/toxicity/demo/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@tensorflow-models/toxicity": "^1.2.2",
-    "@tensorflow/tfjs": "^1.2.9"
+    "@tensorflow/tfjs": "^1.3.3"
   },
   "scripts": {
     "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open ",

--- a/toxicity/demo/package.json
+++ b/toxicity/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toxicity_demo",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "index.js",
   "license": "Apache-2.0",
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow-models/toxicity": "1.2.0",
+    "@tensorflow-models/toxicity": "^1.2.2",
     "@tensorflow/tfjs": "^1.2.9"
   },
   "scripts": {

--- a/toxicity/demo/yarn.lock
+++ b/toxicity/demo/yarn.lock
@@ -807,25 +807,27 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@tensorflow-models/toxicity@file:..":
-  version "1.2.1"
+"@tensorflow-models/toxicity@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow-models/toxicity/-/toxicity-1.2.2.tgz#aed2cc92122f2fc949b42502bb55f8ed2e1d03a8"
+  integrity sha512-DSMIoBzNyX7+4D4cGKjsFLbCuJz3bksYpwFHKAjTp4+tmgAGpNyg5nDXXI/IQp18nMTbLKgLruLWOxq5y7P4WQ==
   dependencies:
-    "@tensorflow-models/universal-sentence-encoder" "~1.2.0"
+    "@tensorflow-models/universal-sentence-encoder" "~1.2.2"
 
-"@tensorflow-models/universal-sentence-encoder@~1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow-models/universal-sentence-encoder/-/universal-sentence-encoder-1.2.0.tgz#a44c5b66a778c49c42c88c775586b7a7f5bc249b"
-  integrity sha512-UV7bXkK+Uns0zPT3TfAQ+A3nhYIC2TMEZJ+7aL0juJ2Nf0NOE+2EBIb90TH9DpiGQukA2AgY2P5hK+bvhc8BZA==
+"@tensorflow-models/universal-sentence-encoder@~1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow-models/universal-sentence-encoder/-/universal-sentence-encoder-1.2.2.tgz#27a38c39424b5e85389ac461be177c9f44ba19bd"
+  integrity sha512-fGCl/gwB7jmKCRI2FhgIBeIa/LCSUcjlEcckH2Bc2dIjhJ+2nspp+22lubxcseN6jjrmP42kkXt/reAPe+KJkQ==
 
-"@tensorflow/tfjs-converter@1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.9.tgz#4774dd9447ac81c0c6776f9fd186374b9fa3bf1a"
-  integrity sha512-OKmiuZicIgadT3Bv9BvM+oom7wRz9eC5rTglQnuv7VN9H0syFVuhf5oD1Ff70tGDhJjJgL+cPz01fZRxTXjRWA==
+"@tensorflow/tfjs-converter@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.0.tgz#f11e7ad3a82e42939039ea2286610a8d77940987"
+  integrity sha512-IvikVcaaCoZhO4NMOH3E5USvdDEmV42Gv2F1lU755CWUZ+NEHkR/uPOdIwmE8ZsfbNdVVegZyaZQRnxju1L2fQ==
 
-"@tensorflow/tfjs-core@1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.2.9.tgz#125830270a0bdd0e856914778a300c4ad6f51e21"
-  integrity sha512-s0hHZSx6rGTlkkB8u8gs5n7sIPv1GXDNHmISRy+kqGzmlpkfI2kr6WXqOWQy6wFgjzopRD8cJQjBZ9USPZnYTQ==
+"@tensorflow/tfjs-core@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.5.0.tgz#a011a68882068d91d82410bb71aa0220867286bc"
+  integrity sha512-UcTAoVNmBxJLktGWUNbSq7ZEgBvjD0SWS0QcRBMgs93AeLM3xhlyo8MqECQsvCkuReDZwVHhX2fjMrf2M3R99w==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"
@@ -834,28 +836,28 @@
     node-fetch "~2.1.2"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-data@1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.2.9.tgz#54030a7990eb58d20288cab099d966d496710760"
-  integrity sha512-Ti9Cj3pte9butuEsK5OPq0Lcqdi4wVUdtQXm0o7iYOZ0umseRzfbIb6zbdqucc2MQzOMTnRoxN+FL7LZmncsHg==
+"@tensorflow/tfjs-data@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-data/-/tfjs-data-1.5.0.tgz#91f0620210806ebdb6fa83f3013db33a325ff7a1"
+  integrity sha512-3o/hzzdIHbLGi6oq+UplsTBpgaEFMVldr7X7n56RoXwSP8jSyhAM0oV2SvrL3rcmNP+5eW+pPodBg4kltZq9yQ==
   dependencies:
     "@types/node-fetch" "^2.1.2"
     node-fetch "~2.1.2"
 
-"@tensorflow/tfjs-layers@1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.2.9.tgz#d30d1bdfed228a07a3d4e9dcb9a6884031ae56e7"
-  integrity sha512-OlXYaIb1rCk5dYmpaNsPEkO7R+T0oxfS3vQGIztNJB+YxrN8mwCu3hqgpbdKhAITiP+jxO0o+7bny8MsOCkOSQ==
+"@tensorflow/tfjs-layers@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.0.tgz#fe8e8a0a35a6999df891e4cff471aac6521d5ed7"
+  integrity sha512-uX5lWiDVrA0KSH2nzbewbBThtcVNVRU+xahm8SsNC7wYvnXAoL8K1X/yAYd+OvgTxbDxo+CW3ORd0S4sZby+yg==
 
-"@tensorflow/tfjs@^1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.2.9.tgz#120f55a2826f71a5816e02b5bc0311fd583beedb"
-  integrity sha512-9UAQnSp638FyM5eedYEM+j2R7VcNajiFmkeT5EXtf7YIurmMFNEm1sbajKJx7/ckz31YcYrVoUPc/iLhhDQl2A==
+"@tensorflow/tfjs@^1.3.3":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-1.5.0.tgz#a0823bea27d1624d6ff4c5a50be2d1a59c937bf0"
+  integrity sha512-y2izi8vkXd9pYcszj3tOj9rkM6lQDMNesVa5AZBsyvFsgpcSiQpYoiyZKOM1YEcmwgNDgvmAUVfKsgqZfl8BLQ==
   dependencies:
-    "@tensorflow/tfjs-converter" "1.2.9"
-    "@tensorflow/tfjs-core" "1.2.9"
-    "@tensorflow/tfjs-data" "1.2.9"
-    "@tensorflow/tfjs-layers" "1.2.9"
+    "@tensorflow/tfjs-converter" "1.5.0"
+    "@tensorflow/tfjs-core" "1.5.0"
+    "@tensorflow/tfjs-data" "1.5.0"
+    "@tensorflow/tfjs-layers" "1.5.0"
 
 "@types/node-fetch@^2.1.2":
   version "2.3.7"

--- a/toxicity/demo/yarn.lock
+++ b/toxicity/demo/yarn.lock
@@ -807,10 +807,8 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@tensorflow-models/toxicity@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow-models/toxicity/-/toxicity-1.2.0.tgz#544f4604e38ff102ed8a55db7d8f7b5a195d8928"
-  integrity sha512-9bGWPpjNpLIjAKmUttUA4YhPCI6Py/zBxA9H+DRzfLE/OUZUYw9Eams7NNiUIOqs3LzM89lqzjF6L2iIXbxOlA==
+"@tensorflow-models/toxicity@file:..":
+  version "1.2.1"
   dependencies:
     "@tensorflow-models/universal-sentence-encoder" "~1.2.0"
 

--- a/toxicity/package.json
+++ b/toxicity/package.json
@@ -13,15 +13,15 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "^1.2.9",
-    "@tensorflow/tfjs-converter": "^1.2.9"
+    "@tensorflow/tfjs-core": "^1.3.3",
+    "@tensorflow/tfjs-converter": "^1.3.3"
   },
   "dependencies": {
-    "@tensorflow-models/universal-sentence-encoder": "~1.2.0"
+    "@tensorflow-models/universal-sentence-encoder": "~1.2.2"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "^1.2.9",
-    "@tensorflow/tfjs-converter": "^1.2.9",
+    "@tensorflow/tfjs-core": "^1.3.3",
+    "@tensorflow/tfjs-converter": "^1.3.3",
     "@types/jasmine": "~2.5.53",
     "babel-core": "^6.26.3",
     "jasmine": "^3.3.1",

--- a/toxicity/package.json
+++ b/toxicity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/toxicity",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Toxicity model in TensorFlow.js",
   "main": "dist/index.js",
   "jsnext:main": "dist/toxicity.esm.js",

--- a/toxicity/src/index.ts
+++ b/toxicity/src/index.ts
@@ -20,9 +20,6 @@ import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
 export {version} from './version';
 
-const BASE_PATH =
-    'https://storage.googleapis.com/tfjs-models/savedmodel/toxicity/';
-
 /**
  * Load the toxicity model.
  *
@@ -52,7 +49,9 @@ export class ToxicityClassifier {
   }
 
   async loadModel() {
-    return tfconv.loadGraphModel(`${BASE_PATH}model.json`);
+    return tfconv.loadGraphModel(
+        'https://tfhub.dev/tensorflow/tfjs-model/toxicity/1/default/1',
+        {fromTFHub: true});
   }
 
   async loadTokenizer() {

--- a/toxicity/src/version.ts
+++ b/toxicity/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '1.2.1';
+const version = '1.2.2';
 export {version};

--- a/toxicity/yarn.lock
+++ b/toxicity/yarn.lock
@@ -18,20 +18,20 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@tensorflow-models/universal-sentence-encoder@~1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow-models/universal-sentence-encoder/-/universal-sentence-encoder-1.2.0.tgz#a44c5b66a778c49c42c88c775586b7a7f5bc249b"
-  integrity sha512-UV7bXkK+Uns0zPT3TfAQ+A3nhYIC2TMEZJ+7aL0juJ2Nf0NOE+2EBIb90TH9DpiGQukA2AgY2P5hK+bvhc8BZA==
+"@tensorflow-models/universal-sentence-encoder@~1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow-models/universal-sentence-encoder/-/universal-sentence-encoder-1.2.2.tgz#27a38c39424b5e85389ac461be177c9f44ba19bd"
+  integrity sha512-fGCl/gwB7jmKCRI2FhgIBeIa/LCSUcjlEcckH2Bc2dIjhJ+2nspp+22lubxcseN6jjrmP42kkXt/reAPe+KJkQ==
 
-"@tensorflow/tfjs-converter@^1.2.9":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.4.0.tgz#c864edd2ec7cc89d3ffd53854e79612fc230ef97"
-  integrity sha512-vdZumj6zHcEALtQlonCBbVwGdEEDcPrF7prgzf4HF82QG4RpM1x/kVdvzsGvfUIPYjRImNn0ZSPC3WaKslNcXw==
+"@tensorflow/tfjs-converter@^1.3.3":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.0.tgz#f11e7ad3a82e42939039ea2286610a8d77940987"
+  integrity sha512-IvikVcaaCoZhO4NMOH3E5USvdDEmV42Gv2F1lU755CWUZ+NEHkR/uPOdIwmE8ZsfbNdVVegZyaZQRnxju1L2fQ==
 
-"@tensorflow/tfjs-core@^1.2.9":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.4.0.tgz#045c91f93cb3ea77473b664c0d1dbad675d7f046"
-  integrity sha512-a7dHhSsBbtaxp8/1UAeYKrjY1bQxsDy/Uhj57+mTuGLAcL8CDrTOXXZzucCgs5nvQErdscp7Gp/2VCcA1xp6XQ==
+"@tensorflow/tfjs-core@^1.3.3":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.5.0.tgz#a011a68882068d91d82410bb71aa0220867286bc"
+  integrity sha512-UcTAoVNmBxJLktGWUNbSq7ZEgBvjD0SWS0QcRBMgs93AeLM3xhlyo8MqECQsvCkuReDZwVHhX2fjMrf2M3R99w==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"

--- a/universal-sentence-encoder/demo/package.json
+++ b/universal-sentence-encoder/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use_demo",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "index.js",
   "license": "Apache-2.0",
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow-models/universal-sentence-encoder": "1.2.0",
+    "@tensorflow-models/universal-sentence-encoder": "^1.2.2",
     "@tensorflow/tfjs": "^1.2.9",
     "d3-scale-chromatic": "^1.3.3"
   },

--- a/universal-sentence-encoder/demo/yarn.lock
+++ b/universal-sentence-encoder/demo/yarn.lock
@@ -742,10 +742,8 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@tensorflow-models/universal-sentence-encoder@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow-models/universal-sentence-encoder/-/universal-sentence-encoder-1.2.0.tgz#a44c5b66a778c49c42c88c775586b7a7f5bc249b"
-  integrity sha512-UV7bXkK+Uns0zPT3TfAQ+A3nhYIC2TMEZJ+7aL0juJ2Nf0NOE+2EBIb90TH9DpiGQukA2AgY2P5hK+bvhc8BZA==
+"@tensorflow-models/universal-sentence-encoder@file:..":
+  version "1.2.1"
 
 "@tensorflow/tfjs-converter@1.2.9":
   version "1.2.9"

--- a/universal-sentence-encoder/demo/yarn.lock
+++ b/universal-sentence-encoder/demo/yarn.lock
@@ -742,8 +742,10 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@tensorflow-models/universal-sentence-encoder@file:..":
-  version "1.2.1"
+"@tensorflow-models/universal-sentence-encoder@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow-models/universal-sentence-encoder/-/universal-sentence-encoder-1.2.2.tgz#27a38c39424b5e85389ac461be177c9f44ba19bd"
+  integrity sha512-fGCl/gwB7jmKCRI2FhgIBeIa/LCSUcjlEcckH2Bc2dIjhJ+2nspp+22lubxcseN6jjrmP42kkXt/reAPe+KJkQ==
 
 "@tensorflow/tfjs-converter@1.2.9":
   version "1.2.9"

--- a/universal-sentence-encoder/package.json
+++ b/universal-sentence-encoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/universal-sentence-encoder",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Universal Sentence Encoder lite in TensorFlow.js",
   "main": "dist/index.js",
   "jsnext:main": "dist/universal-sentence-encoder.esm.js",

--- a/universal-sentence-encoder/src/index.ts
+++ b/universal-sentence-encoder/src/index.ts
@@ -58,7 +58,9 @@ export class UniversalSentenceEncoder {
   private tokenizer: Tokenizer;
 
   async loadModel() {
-    return tfconv.loadGraphModel(`${BASE_PATH}model.json`);
+    return tfconv.loadGraphModel(
+        'https://tfhub.dev/tensorflow/tfjs-model/universal-sentence-encoder-lite/1/default/1',
+        {fromTFHub: true});
   }
 
   async load() {

--- a/universal-sentence-encoder/src/version.ts
+++ b/universal-sentence-encoder/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '1.2.1';
+const version = '1.2.2';
 export {version};


### PR DESCRIPTION
The lockfiles for the demos need to be updated after the modules are actually published.

I thought the workflow could be: once I get approval on this PR, I'll publish both USE and toxicity to NPM. Then I'll upgrade the yarn.lock files for both demos. Then I'll merge into master.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/381)
<!-- Reviewable:end -->
