### PR TITLE
[Bug] Fix property renaming issue

### DIFF
--- a/toxicity/src/index.ts
+++ b/toxicity/src/index.ts
@@ -20,6 +20,11 @@ import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
 export {version} from './version';
 
+declare interface ModelInputs extends tf.NamedTensorMap {
+  Placeholder_1: tf.Tensor;
+  Placeholder: tf.Tensor;
+}
+
 /**
  * Load the toxicity model.
  *
@@ -112,8 +117,12 @@ export class ToxicityClassifier {
         flattenedIndicesArr, [flattenedIndicesArr.length, 2], 'int32');
     const values = tf.tensor1d(tf.util.flatten(encodings) as number[], 'int32');
 
-    const labels = await this.model.executeAsync(
-        {Placeholder_1: indices, Placeholder: values});
+    const modelInputs: ModelInputs = {
+      Placeholder_1: indices,
+      Placeholder: values
+    };
+
+    const labels = await this.model.executeAsync(modelInputs);
 
     indices.dispose();
     values.dispose();

--- a/universal-sentence-encoder/src/index.ts
+++ b/universal-sentence-encoder/src/index.ts
@@ -25,6 +25,11 @@ export {version} from './version';
 const BASE_PATH =
     'https://storage.googleapis.com/tfjs-models/savedmodel/universal_sentence_encoder/';
 
+declare interface ModelInputs extends tf.NamedTensorMap {
+  indices: tf.Tensor;
+  values: tf.Tensor;
+}
+
 export async function load() {
   const use = new UniversalSentenceEncoder();
   await use.load();
@@ -98,7 +103,9 @@ export class UniversalSentenceEncoder {
         flattenedIndicesArr, [flattenedIndicesArr.length, 2], 'int32');
     const values = tf.tensor1d(tf.util.flatten(encodings) as number[], 'int32');
 
-    const embeddings = await this.model.executeAsync({indices, values});
+    const modelInputs: ModelInputs = {indices, values};
+
+    const embeddings = await this.model.executeAsync(modelInputs);
     indices.dispose();
     values.dispose();
 


### PR DESCRIPTION
Property renaming only happens with JSCompiler. Declare an interface for the properties will prevent JSCompiler renaming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/391)
<!-- Reviewable:end -->
