### PR TITLE
[blazeface] Enable getting bounding boxes only, export more types.

### DIFF
--- a/blazeface/demo/index.js
+++ b/blazeface/demo/index.js
@@ -57,7 +57,8 @@ const renderPrediction = async () => {
 
   const returnTensors = false;
   const flipHorizontal = true;
-  let predictions = await model.estimateFaces(video, returnTensors, flipHorizontal);
+  const annotateBoxes = true;
+  const predictions = await model.estimateFaces(video, returnTensors, flipHorizontal, annotateBoxes);
 
   if (predictions.length > 0) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -69,13 +70,15 @@ const renderPrediction = async () => {
       ctx.fillStyle = "rgba(255, 0, 0, 0.5)";
       ctx.fillRect(start[0], start[1], size[0], size[1]);
 
-      const landmarks = predictions[i].landmarks;
+      if(annotateBoxes) {
+        const landmarks = predictions[i].landmarks;
 
-      ctx.fillStyle = "blue";
-      for (let j = 0; j < landmarks.length; j++) {
-        const x = landmarks[j][0];
-        const y = landmarks[j][1];
-        ctx.fillRect(x, y, 5, 5);
+        ctx.fillStyle = "blue";
+        for (let j = 0; j < landmarks.length; j++) {
+          const x = landmarks[j][0];
+          const y = landmarks[j][1];
+          ctx.fillRect(x, y, 5, 5);
+        }
       }
     }
   }

--- a/blazeface/demo/index.js
+++ b/blazeface/demo/index.js
@@ -70,7 +70,7 @@ const renderPrediction = async () => {
       ctx.fillStyle = "rgba(255, 0, 0, 0.5)";
       ctx.fillRect(start[0], start[1], size[0], size[1]);
 
-      if(annotateBoxes) {
+      if (annotateBoxes) {
         const landmarks = predictions[i].landmarks;
 
         ctx.fillStyle = "blue";

--- a/blazeface/demo/package.json
+++ b/blazeface/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blazeface_demo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "license": "Apache-2.0",
@@ -9,9 +9,9 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow-models/blazeface": "0.0.3",
-    "@tensorflow/tfjs-core": "^1.5.0",
-    "@tensorflow/tfjs-converter": "^1.5.0",
+    "@tensorflow-models/blazeface": "0.0.4",
+    "@tensorflow/tfjs-core": "^1.5.2",
+    "@tensorflow/tfjs-converter": "^1.5.2",
     "@tensorflow/tfjs-backend-wasm": "^1.5.1-alpha5"
   },
   "scripts": {

--- a/blazeface/demo/yarn.lock
+++ b/blazeface/demo/yarn.lock
@@ -697,7 +697,7 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@tensorflow-models/blazeface@0.0.3":
+"@tensorflow-models/blazeface@0.0.4":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@tensorflow-models/blazeface/-/blazeface-0.0.3.tgz#c83c77d9dece3a2c5fec8c3e39fc7dd7ff28d540"
   integrity sha512-ZYup8woiixWvcB0+jCR8TfDGwRtkvVcVTh2W+4a2MCcUCnxZN8mDq+4C97IzpUTeuvHHie7LdBg++LgapRdjCQ==
@@ -709,15 +709,15 @@
   dependencies:
     "@types/emscripten" "~0.0.34"
 
-"@tensorflow/tfjs-converter@^1.5.0":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.1.tgz#13b76266d51c7e7f3aeee27cdc65444a48e01538"
-  integrity sha512-M9tl2/ep8ntcZpmncHwKuvThsS7TaUWqJ9vJSgJmkazwTfAvlAJmZ8/p1miJ+m5sH1EJO4oTjiEmch6g8IA5IQ==
+"@tensorflow/tfjs-converter@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.2.tgz#ec1373f421313bdc6aac46d5578deb58e5093e8c"
+  integrity sha512-RRrB8lZFxjLPHO6TwEJPgViVuJP5yqq0IPqA35PhWLYjsNNuC6Tx8vxEa5BZ0Le0mX21CTURak6pdmyac/Jc2w==
 
-"@tensorflow/tfjs-core@^1.5.0":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.5.1.tgz#490209617f744fef660e8f81fe8b858e95b0d10b"
-  integrity sha512-N4fsi8mLsRwRs8UJN2cARB1rYFxyVXkLyZ4wOusiR976BwwZbCwQrTTSIPzPqYT3rwiexEUzm7sM6ZaDl5dpXA==
+"@tensorflow/tfjs-core@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.5.2.tgz#df76752cf7c43987df1548fb69820935bd8215d7"
+  integrity sha512-Rj6l8xf0PxrEKctvX3bvxjqhHLaCBQT0ChvqFK6//HBu8A1/ao4SzeVKpXKNnP9Niax+qV3c9U9VcOwwIkCMag==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"

--- a/blazeface/demo/yarn.lock
+++ b/blazeface/demo/yarn.lock
@@ -698,9 +698,9 @@
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@tensorflow-models/blazeface@0.0.4":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow-models/blazeface/-/blazeface-0.0.3.tgz#c83c77d9dece3a2c5fec8c3e39fc7dd7ff28d540"
-  integrity sha512-ZYup8woiixWvcB0+jCR8TfDGwRtkvVcVTh2W+4a2MCcUCnxZN8mDq+4C97IzpUTeuvHHie7LdBg++LgapRdjCQ==
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@tensorflow-models/blazeface/-/blazeface-0.0.4.tgz#ce20aafd29be86c7d8c90b44b8a670c5546552e6"
+  integrity sha512-Wm5iaofbb7N58MIt8Q/wdn2mAnPh60JUfleA471yY8hNfS02srZu5mq/0ZSWT0fF5ofIXdp2d07AuHR6TTOy1g==
 
 "@tensorflow/tfjs-backend-wasm@^1.5.1-alpha5":
   version "1.5.1-alpha5"

--- a/blazeface/package.json
+++ b/blazeface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/blazeface",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pretrained face detection model in TensorFlow.js",
   "main": "dist/index.js",
   "jsnext:main": "dist/blazeface.esm.js",
@@ -13,12 +13,12 @@
     "url": "https://github.com/tensorflow/tfjs-models.git"
   },
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "^1.3.2",
-    "@tensorflow/tfjs-converter": "^1.3.2"
+    "@tensorflow/tfjs-core": "^1.5.2",
+    "@tensorflow/tfjs-converter": "^1.5.2"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "^1.3.2",
-    "@tensorflow/tfjs-converter": "^1.3.2",
+    "@tensorflow/tfjs-core": "^1.5.2",
+    "@tensorflow/tfjs-converter": "^1.5.2",
     "@types/jasmine": "~2.5.53",
     "jasmine": "~3.2.0",
     "jasmine-core": "~3.1.0",

--- a/blazeface/src/face.ts
+++ b/blazeface/src/face.ts
@@ -114,17 +114,17 @@ function getInputTensorDimensions(input: tf.Tensor3D|ImageData|HTMLVideoElement|
 function flipFaceHorizontal(
     face: NormalizedFace, imageWidth: number): NormalizedFace {
   let flipped;
-  if (face.topLeft instanceof tf.Tensor && face.bottomRight instanceof 
-    tf.Tensor) {
+  if (face.topLeft instanceof tf.Tensor &&
+      face.bottomRight instanceof tf.Tensor) {
     flipped = Object.assign({}, face, {
       topLeft: tf.concat([
         tf.sub(imageWidth - 1, face.topLeft.slice(0, 1)),
         face.topLeft.slice(1, 1)
-      ]) as tf.Tensor1D,
+      ]),
       bottomRight: tf.concat([
         tf.sub(imageWidth - 1, face.bottomRight.slice(0, 1)),
         face.bottomRight.slice(1, 1)
-      ]) as tf.Tensor1D
+      ])
     });
 
     if (face.landmarks) {
@@ -138,9 +138,7 @@ function flipFaceHorizontal(
     const [bottomRightX, bottomRightY] = face.bottomRight as [number, number];
     flipped = Object.assign({}, face, {
       topLeft: [imageWidth - 1 - topLeftX, topLeftY],
-      bottomRight: [
-        imageWidth - 1 - bottomRightX, bottomRightY
-      ]
+      bottomRight: [imageWidth - 1 - bottomRightX, bottomRightY]
     });
 
     if (face.landmarks) {

--- a/blazeface/src/face.ts
+++ b/blazeface/src/face.ts
@@ -387,11 +387,11 @@ export class BlazeFaceModel {
                      ]));
 
         normalizedFace = {
-          topLeft: (boxData as number[]).slice(0, 2),
-          bottomRight: (boxData as number[]).slice(2),
+          topLeft: (boxData as number[]).slice(0, 2) as [number, number],
+          bottomRight: (boxData as number[]).slice(2) as [number, number],
           landmarks: scaledLandmarks,
-          probability: probabilityData
-        } as NormalizedFace;
+          probability: probabilityData as number
+        };
 
         disposeBox(face.box);
         face.landmarks.dispose();

--- a/blazeface/src/face.ts
+++ b/blazeface/src/face.ts
@@ -114,15 +114,16 @@ function getInputTensorDimensions(input: tf.Tensor3D|ImageData|HTMLVideoElement|
 function flipFaceHorizontal(
     face: NormalizedFace, imageWidth: number): NormalizedFace {
   let flipped;
-  if (face.topLeft instanceof tf.Tensor) {
+  if (face.topLeft instanceof tf.Tensor && face.bottomRight instanceof 
+    tf.Tensor) {
     flipped = Object.assign({}, face, {
       topLeft: tf.concat([
         tf.sub(imageWidth - 1, face.topLeft.slice(0, 1)),
         face.topLeft.slice(1, 1)
       ]) as tf.Tensor1D,
       bottomRight: tf.concat([
-        tf.sub(imageWidth - 1, (face.bottomRight as tf.Tensor).slice(0, 1)),
-        (face.bottomRight as tf.Tensor).slice(1, 1)
+        tf.sub(imageWidth - 1, face.bottomRight.slice(0, 1)),
+        face.bottomRight.slice(1, 1)
       ]) as tf.Tensor1D
     });
 
@@ -133,11 +134,12 @@ function flipFaceHorizontal(
       flipped['landmarks'] = flippedLandmarks;
     }
   } else {
+    const [topLeftX, topLeftY] = face.topLeft as [number, number];
+    const [bottomRightX, bottomRightY] = face.bottomRight as [number, number];
     flipped = Object.assign({}, face, {
-      topLeft: [imageWidth - 1 - face.topLeft[0], face.topLeft[1]],
+      topLeft: [imageWidth - 1 - topLeftX, topLeftY],
       bottomRight: [
-        imageWidth - 1 - (face.bottomRight as [number, number])[0],
-        (face.bottomRight as [number, number])[1]
+        imageWidth - 1 - bottomRightX, bottomRightY
       ]
     });
 

--- a/blazeface/src/face.ts
+++ b/blazeface/src/face.ts
@@ -113,7 +113,7 @@ function getInputTensorDimensions(input: tf.Tensor3D|ImageData|HTMLVideoElement|
 
 function flipFaceHorizontal(
     face: NormalizedFace, imageWidth: number): NormalizedFace {
-  let flipped;
+  let flipped: NormalizedFace;
   if (face.topLeft instanceof tf.Tensor &&
       face.bottomRight instanceof tf.Tensor) {
     flipped = Object.assign({}, face, {
@@ -127,11 +127,11 @@ function flipFaceHorizontal(
       ])
     });
 
-    if (face.landmarks) {
+    if (face.landmarks != null) {
       const flippedLandmarks: tf.Tensor2D =
           tf.sub(tf.tensor1d([imageWidth - 1, 0]), face.landmarks)
               .mul(tf.tensor1d([1, -1]));
-      flipped['landmarks'] = flippedLandmarks;
+      flipped.landmarks = flippedLandmarks;
     }
   } else {
     const [topLeftX, topLeftY] = face.topLeft as [number, number];
@@ -141,8 +141,8 @@ function flipFaceHorizontal(
       bottomRight: [imageWidth - 1 - bottomRightX, bottomRightY]
     });
 
-    if (face.landmarks) {
-      flipped['landmarks'] =
+    if (face.landmarks != null) {
+      flipped.landmarks =
           (face.landmarks as number[][]).map((coord: [number, number]) => ([
                                                imageWidth - 1 - coord[0],
                                                coord[1]
@@ -351,8 +351,8 @@ export class BlazeFaceModel {
 
           const normalizedLandmarks: tf.Tensor2D =
               landmarks.add(anchor).mul(scaleFactor);
-          normalizedFace['landmarks'] = normalizedLandmarks;
-          normalizedFace['probability'] = probability;
+          normalizedFace.landmarks = normalizedLandmarks;
+          normalizedFace.probability = probability;
         }
 
         if (flipHorizontal) {

--- a/blazeface/src/face.ts
+++ b/blazeface/src/face.ts
@@ -29,14 +29,14 @@ export interface NormalizedFace {
   /** The lower right-hand corner of the face. */
   bottomRight: [number, number]|tf.Tensor1D;
   /** Facial landmark coordinates. */
-  landmarks: number[][]|tf.Tensor2D;
+  landmarks?: number[][]|tf.Tensor2D;
   /** Probability of the face detection. */
-  probability: number|tf.Tensor1D;
+  probability?: number|tf.Tensor1D;
 }
 
 // The blazeface model predictions containing unnormalized coordinates
 // for facial bounding box / landmarks.
-type BlazeFacePrediction = {
+export type BlazeFacePrediction = {
   box: Box,
   landmarks: tf.Tensor2D,
   probability: tf.Tensor1D,
@@ -113,8 +113,9 @@ function getInputTensorDimensions(input: tf.Tensor3D|ImageData|HTMLVideoElement|
 
 function flipFaceHorizontal(
     face: NormalizedFace, imageWidth: number): NormalizedFace {
+  let flipped;
   if (face.topLeft instanceof tf.Tensor) {
-    return {
+    flipped = Object.assign({}, face, {
       topLeft: tf.concat([
         tf.sub(imageWidth - 1, face.topLeft.slice(0, 1)),
         face.topLeft.slice(1, 1)
@@ -122,25 +123,47 @@ function flipFaceHorizontal(
       bottomRight: tf.concat([
         tf.sub(imageWidth - 1, (face.bottomRight as tf.Tensor).slice(0, 1)),
         (face.bottomRight as tf.Tensor).slice(1, 1)
-      ]) as tf.Tensor1D,
-      landmarks: tf.sub(tf.tensor1d([imageWidth - 1, 0]), face.landmarks)
-                     .mul(tf.tensor1d([1, -1])) as tf.Tensor2D,
-      probability: face.probability
-    } as NormalizedFace;
+      ]) as tf.Tensor1D
+    });
+
+    if (face.landmarks) {
+      const flippedLandmarks: tf.Tensor2D =
+          tf.sub(tf.tensor1d([imageWidth - 1, 0]), face.landmarks)
+              .mul(tf.tensor1d([1, -1]));
+      flipped['landmarks'] = flippedLandmarks;
+    }
+  } else {
+    flipped = Object.assign({}, face, {
+      topLeft: [imageWidth - 1 - face.topLeft[0], face.topLeft[1]],
+      bottomRight: [
+        imageWidth - 1 - (face.bottomRight as [number, number])[0],
+        (face.bottomRight as [number, number])[1]
+      ]
+    });
+
+    if (face.landmarks) {
+      flipped['landmarks'] =
+          (face.landmarks as number[][]).map((coord: [number, number]) => ([
+                                               imageWidth - 1 - coord[0],
+                                               coord[1]
+                                             ]));
+    }
   }
 
-  return {
-    topLeft: [imageWidth - 1 - face.topLeft[0], face.topLeft[1]],
-    bottomRight: [
-      imageWidth - 1 - (face.bottomRight as [number, number])[0],
-      (face.bottomRight as [number, number])[1]
-    ],
-    landmarks:
-        (face.landmarks as number[][]).map((coord: [number, number]) => ([
-                                             imageWidth - 1 - coord[0], coord[1]
-                                           ])),
-    probability: face.probability
-  };
+  return flipped;
+}
+
+function scaleBoxFromPrediction(
+    face: BlazeFacePrediction|Box, scaleFactor: tf.Tensor1D|[number, number]) {
+  return tf.tidy(() => {
+    let box;
+    if (face.hasOwnProperty('box')) {
+      box = (face as BlazeFacePrediction).box;
+    } else {
+      box = face;
+    }
+    return scaleBox(box as Box, scaleFactor).startEndTensor.squeeze();
+  });
 }
 
 export class BlazeFaceModel {
@@ -174,9 +197,15 @@ export class BlazeFaceModel {
     this.scoreThreshold = scoreThreshold;
   }
 
-  async getBoundingBoxes(inputImage: tf.Tensor4D, returnTensors: boolean):
-      Promise<[BlazeFacePrediction[], tf.Tensor|[number, number]]> {
-    const [detectedOutputs, boxes, scores] = tf.tidy(() => {
+  async getBoundingBoxes(
+      inputImage: tf.Tensor4D, returnTensors: boolean,
+      annotateBoxes = true): Promise<{
+    boxes: Array<BlazeFacePrediction|Box>,
+    scaleFactor: tf.Tensor|[number, number]
+  }> {
+    const [detectedOutputs, boxes, scores] = tf.tidy((): [
+      tf.Tensor2D, tf.Tensor2D, tf.Tensor1D
+    ] => {
       const resizedImage = inputImage.resizeBilinear([this.width, this.height]);
       const normalizedImage = tf.mul(tf.sub(resizedImage.div(255), 0.5), 2);
 
@@ -187,18 +216,18 @@ export class BlazeFaceModel {
       const decodedBounds =
           decodeBounds(prediction as tf.Tensor2D, this.anchors, this.inputSize);
       const logits = tf.slice(prediction as tf.Tensor2D, [0, 0], [-1, 1]);
-      return [prediction, decodedBounds, tf.sigmoid(logits).squeeze()];
+      const scores = tf.sigmoid(logits).squeeze();
+      return [prediction as tf.Tensor2D, decodedBounds, scores as tf.Tensor1D];
     });
 
     // TODO: Once tf.image.nonMaxSuppression includes a flag to suppress console
     // warnings for not using async version, pass that flag in.
     const savedConsoleWarnFn = console.warn;
     console.warn = () => {};
-
     const boxIndicesTensor = tf.image.nonMaxSuppression(
-        boxes as tf.Tensor2D, scores as tf.Tensor1D, this.maxFaces,
-        this.iouThreshold, this.scoreThreshold);
+        boxes, scores, this.maxFaces, this.iouThreshold, this.scoreThreshold);
     console.warn = savedConsoleWarnFn;
+
     const boxIndices = await boxIndicesTensor.array();
     boxIndicesTensor.dispose();
 
@@ -231,6 +260,14 @@ export class BlazeFaceModel {
             .map(
                 (boundingBox: tf.Tensor2D|number[][], i: number) =>
                     tf.tidy(() => {
+                      const box = boundingBox instanceof tf.Tensor ?
+                          createBox(boundingBox) :
+                          createBox(tf.tensor2d(boundingBox));
+
+                      if (!annotateBoxes) {
+                        return box;
+                      }
+
                       const boxIndex = boxIndices[i];
 
                       let anchor;
@@ -240,9 +277,6 @@ export class BlazeFaceModel {
                         anchor = this.anchorsData[boxIndex] as [number, number];
                       }
 
-                      const box = boundingBox instanceof tf.Tensor ?
-                          createBox(boundingBox) :
-                          createBox(tf.tensor2d(boundingBox));
                       const landmarks =
                           tf.slice(
                                 detectedOutputs, [boxIndex, NUM_LANDMARKS - 1],
@@ -258,7 +292,10 @@ export class BlazeFaceModel {
     scores.dispose();
     detectedOutputs.dispose();
 
-    return [annotatedBoxes as BlazeFacePrediction[], scaleFactor];
+    return {
+      boxes: annotatedBoxes as Array<BlazeFacePrediction|Box>,
+      scaleFactor
+    };
   }
 
   /**
@@ -271,6 +308,8 @@ export class BlazeFaceModel {
    * @param flipHorizontal Whether to flip/mirror the facial keypoints
    * horizontally. Should be true for videos that are flipped by default (e.g.
    * webcams).
+   * @param annotateBoxes Whether to annotate bounding boxes with additional
+   * properties such as landmarks and probability.
    *
    * @return An array of detected faces, each with the following properties:
    *  `topLeft`: the upper left coordinate of the face in the form `[x, y]`
@@ -281,8 +320,8 @@ export class BlazeFaceModel {
   async estimateFaces(
       input: tf.Tensor3D|ImageData|HTMLVideoElement|HTMLImageElement|
       HTMLCanvasElement,
-      returnTensors = false,
-      flipHorizontal = false): Promise<NormalizedFace[]> {
+      returnTensors = false, flipHorizontal = false,
+      annotateBoxes = true): Promise<NormalizedFace[]> {
     const [, width] = getInputTensorDimensions(input);
     const image = tf.tidy(() => {
       if (!(input instanceof tf.Tensor)) {
@@ -290,61 +329,77 @@ export class BlazeFaceModel {
       }
       return (input as tf.Tensor).toFloat().expandDims(0);
     });
-    const [prediction, scaleFactor] =
-        await this.getBoundingBoxes(image as tf.Tensor4D, returnTensors);
+    const {boxes, scaleFactor} = await this.getBoundingBoxes(
+        image as tf.Tensor4D, returnTensors, annotateBoxes);
     image.dispose();
 
     if (returnTensors) {
-      return prediction.map((face: BlazeFacePrediction) => {
-        const scaledBox = scaleBox(face.box, scaleFactor as tf.Tensor1D)
-                              .startEndTensor.squeeze();
+      return boxes.map((face: BlazeFacePrediction|Box) => {
+        const scaledBox =
+            scaleBoxFromPrediction(face, scaleFactor as tf.Tensor1D);
+        let normalizedFace: NormalizedFace = {
+          topLeft: scaledBox.slice([0], [2]) as tf.Tensor1D,
+          bottomRight: scaledBox.slice([2], [2]) as tf.Tensor1D
+        };
 
-        let normalizedFace = {
-          topLeft: scaledBox.slice([0], [2]),
-          bottomRight: scaledBox.slice([2], [2]),
-          landmarks: face.landmarks.add(face.anchor).mul(scaleFactor),
-          probability: face.probability
-        } as NormalizedFace;
+        if (annotateBoxes) {
+          const {landmarks, probability, anchor} = face as {
+            landmarks: tf.Tensor2D,
+            probability: tf.Tensor1D,
+            anchor: tf.Tensor2D | [number, number]
+          };
+
+          const normalizedLandmarks: tf.Tensor2D =
+              landmarks.add(anchor).mul(scaleFactor);
+          normalizedFace['landmarks'] = normalizedLandmarks;
+          normalizedFace['probability'] = probability;
+        }
+
         if (flipHorizontal) {
-          normalizedFace =
-              flipFaceHorizontal(normalizedFace as NormalizedFace, width) as
-              NormalizedFace;
+          normalizedFace = flipFaceHorizontal(normalizedFace, width);
         }
         return normalizedFace;
       });
     }
 
-    return Promise.all(prediction.map(async (face: BlazeFacePrediction) => {
-      const scaledBox = tf.tidy(() => {
-        return scaleBox(face.box, scaleFactor as [number, number])
-            .startEndTensor.squeeze();
-      });
+    return Promise.all(boxes.map(async (face: BlazeFacePrediction) => {
+      const scaledBox =
+          scaleBoxFromPrediction(face, scaleFactor as [number, number]);
+      let normalizedFace: NormalizedFace;
+      if (!annotateBoxes) {
+        const boxData = await scaledBox.array();
+        normalizedFace = {
+          topLeft: (boxData as number[]).slice(0, 2) as [number, number],
+          bottomRight: (boxData as number[]).slice(2) as [number, number]
+        };
+      } else {
+        const [landmarkData, boxData, probabilityData] =
+            await Promise.all([face.landmarks, scaledBox, face.probability].map(
+                async d => d.array()));
 
-      const [landmarkData, boxData, probabilityData] =
-          await Promise.all([face.landmarks, scaledBox, face.probability].map(
-              async d => d.array()));
+        const anchor = face.anchor as [number, number];
+        const scaledLandmarks =
+            (landmarkData as number[][])
+                .map((landmark: [number, number]) => ([
+                       (landmark[0] + anchor[0]) *
+                           (scaleFactor as [number, number])[0],
+                       (landmark[1] + anchor[1]) *
+                           (scaleFactor as [number, number])[1]
+                     ]));
 
-      const anchor = face.anchor as [number, number];
-      const scaledLandmarks =
-          (landmarkData as number[][])
-              .map((landmark: [number, number]) => ([
-                     (landmark[0] + anchor[0]) *
-                         (scaleFactor as [number, number])[0],
-                     (landmark[1] + anchor[1]) *
-                         (scaleFactor as [number, number])[1]
-                   ]));
+        normalizedFace = {
+          topLeft: (boxData as number[]).slice(0, 2),
+          bottomRight: (boxData as number[]).slice(2),
+          landmarks: scaledLandmarks,
+          probability: probabilityData
+        } as NormalizedFace;
+
+        disposeBox(face.box);
+        face.landmarks.dispose();
+        face.probability.dispose();
+      }
 
       scaledBox.dispose();
-      disposeBox(face.box);
-      face.landmarks.dispose();
-      face.probability.dispose();
-
-      let normalizedFace = {
-        topLeft: (boxData as number[]).slice(0, 2),
-        bottomRight: (boxData as number[]).slice(2),
-        landmarks: scaledLandmarks,
-        probability: probabilityData
-      } as NormalizedFace;
 
       if (flipHorizontal) {
         normalizedFace = flipFaceHorizontal(normalizedFace, width);

--- a/blazeface/src/face.ts
+++ b/blazeface/src/face.ts
@@ -378,13 +378,12 @@ export class BlazeFaceModel {
                 async d => d.array()));
 
         const anchor = face.anchor as [number, number];
+        const [scaleFactorX, scaleFactorY] = scaleFactor as [number, number];
         const scaledLandmarks =
-            (landmarkData as number[][])
-                .map((landmark: [number, number]) => ([
-                       (landmark[0] + anchor[0]) *
-                           (scaleFactor as [number, number])[0],
-                       (landmark[1] + anchor[1]) *
-                           (scaleFactor as [number, number])[1]
+            (landmarkData as Array<[number, number]>)
+                .map(landmark => ([
+                       (landmark[0] + anchor[0]) * scaleFactorX,
+                       (landmark[1] + anchor[1]) * scaleFactorY
                      ]));
 
         normalizedFace = {

--- a/blazeface/src/face.ts
+++ b/blazeface/src/face.ts
@@ -114,6 +114,13 @@ function getInputTensorDimensions(input: tf.Tensor3D|ImageData|HTMLVideoElement|
 function flipFaceHorizontal(
     face: NormalizedFace, imageWidth: number): NormalizedFace {
   let flipped: NormalizedFace;
+
+  if (face.probability != null) {
+    flipped.probability = face.probability instanceof tf.Tensor ?
+        face.probability.clone() :
+        face.probability;
+  }
+
   if (face.topLeft instanceof tf.Tensor &&
       face.bottomRight instanceof tf.Tensor) {
     const [topLeft, bottomRight] = tf.tidy(() => {
@@ -121,15 +128,15 @@ function flipFaceHorizontal(
         tf.concat([
           tf.sub(imageWidth - 1, (face.topLeft as tf.Tensor).slice(0, 1)),
           (face.topLeft as tf.Tensor).slice(1, 1)
-        ]),
+        ]) as tf.Tensor1D,
         tf.concat([
           tf.sub(imageWidth - 1, (face.bottomRight as tf.Tensor).slice(0, 1)),
           (face.bottomRight as tf.Tensor).slice(1, 1)
-        ])
+        ]) as tf.Tensor1D
       ];
     });
 
-    flipped = Object.assign({}, face, {topLeft, bottomRight});
+    flipped = {topLeft, bottomRight};
 
     if (face.landmarks != null) {
       const flippedLandmarks: tf.Tensor2D = tf.tidy(
@@ -140,10 +147,10 @@ function flipFaceHorizontal(
   } else {
     const [topLeftX, topLeftY] = face.topLeft as [number, number];
     const [bottomRightX, bottomRightY] = face.bottomRight as [number, number];
-    flipped = Object.assign({}, face, {
+    flipped = {
       topLeft: [imageWidth - 1 - topLeftX, topLeftY],
       bottomRight: [imageWidth - 1 - bottomRightX, bottomRightY]
-    });
+    };
 
     if (face.landmarks != null) {
       flipped.landmarks =

--- a/blazeface/src/index.ts
+++ b/blazeface/src/index.ts
@@ -49,4 +49,4 @@ export async function load({
   return model;
 }
 
-export {NormalizedFace, BlazeFaceModel} from './face';
+export {NormalizedFace, BlazeFaceModel, BlazeFacePrediction} from './face';

--- a/blazeface/src/version.ts
+++ b/blazeface/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '0.0.3';
+const version = '0.0.4';
 export {version};

--- a/blazeface/yarn.lock
+++ b/blazeface/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@tensorflow/tfjs-converter@^1.3.2":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.4.0.tgz#c864edd2ec7cc89d3ffd53854e79612fc230ef97"
-  integrity sha512-vdZumj6zHcEALtQlonCBbVwGdEEDcPrF7prgzf4HF82QG4RpM1x/kVdvzsGvfUIPYjRImNn0ZSPC3WaKslNcXw==
+"@tensorflow/tfjs-converter@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.2.tgz#ec1373f421313bdc6aac46d5578deb58e5093e8c"
+  integrity sha512-RRrB8lZFxjLPHO6TwEJPgViVuJP5yqq0IPqA35PhWLYjsNNuC6Tx8vxEa5BZ0Le0mX21CTURak6pdmyac/Jc2w==
 
-"@tensorflow/tfjs-core@^1.3.2":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.4.0.tgz#045c91f93cb3ea77473b664c0d1dbad675d7f046"
-  integrity sha512-a7dHhSsBbtaxp8/1UAeYKrjY1bQxsDy/Uhj57+mTuGLAcL8CDrTOXXZzucCgs5nvQErdscp7Gp/2VCcA1xp6XQ==
+"@tensorflow/tfjs-core@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.5.2.tgz#df76752cf7c43987df1548fb69820935bd8215d7"
+  integrity sha512-Rj6l8xf0PxrEKctvX3bvxjqhHLaCBQT0ChvqFK6//HBu8A1/ao4SzeVKpXKNnP9Niax+qV3c9U9VcOwwIkCMag==
   dependencies:
     "@types/offscreencanvas" "~2019.3.0"
     "@types/seedrandom" "2.4.27"


### PR DESCRIPTION
Facemesh will depend on blazeface for bounding box detection. This PR makes it possible to fetch only the bounding boxes from blazeface without paying for other properties like facial landmarks.

Will update demo yarn.lock file after publishing blazeface, then will merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/397)
<!-- Reviewable:end -->
