### PR TITLE
Fix typo speech-commands/README.md

### DIFF
--- a/speech-commands/README.md
+++ b/speech-commands/README.md
@@ -162,7 +162,7 @@ tf.dispose([x, output]);
 ```
 
 Note that you must provide a spectrogram value to the `recognize()` call
-in order to perform the offline recognition. If `recognzie()` as called
+in order to perform the offline recognition. If `recognize()` is called
 without a first argument, it will perform one-shot online recognition
 by collecting a frame of audio via WebAudio.
 


### PR DESCRIPTION
Little typo error in README

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/409)
<!-- Reviewable:end -->
