### PR TITLE
[handpose] Update asset URLs to use mediapipe

### DIFF
--- a/handpose/demo/package.json
+++ b/handpose/demo/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow-models/handpose": "0.0.2",
+    "@tensorflow-models/handpose": "0.0.3",
     "@tensorflow/tfjs-core": "^1.6.1",
     "@tensorflow/tfjs-converter": "^1.6.1"
   },

--- a/handpose/demo/yarn.lock
+++ b/handpose/demo/yarn.lock
@@ -815,10 +815,8 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@tensorflow-models/handpose@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@tensorflow-models/handpose/-/handpose-0.0.2.tgz#d5ce96f42a418bd9278e48f5ce5762933dba4242"
-  integrity sha512-3F9uf+WAVhkUPZ08aswk0YIQiauVxSnKYhOXEheFmZM5QOHAz50A223/5b26iXi5OAM7/KiddfSPgTko7JQiQQ==
+"@tensorflow-models/handpose@file:..":
+  version "0.0.3"
 
 "@tensorflow/tfjs-converter@^1.6.1":
   version "1.6.1"

--- a/handpose/package.json
+++ b/handpose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/handpose",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pretrained hand detection model",
   "main": "dist/index.js",
   "jsnext:main": "dist/handpose.esm.js",

--- a/handpose/src/index.ts
+++ b/handpose/src/index.ts
@@ -45,7 +45,7 @@ async function loadHandPoseModel() {
 async function loadAnchors() {
   return tf.util
       .fetch(
-          'https://storage.googleapis.com/tfhub-tfjs-modules/tensorflow/tfjs-model/handskeleton/1/default/1/anchors.json')
+          'https://tfhub.dev/tensorflow/tfjs-model/handskeleton/1/default/1/anchors.json?tfjs-format=file')
       .then(d => d.json());
 }
 

--- a/handpose/src/index.ts
+++ b/handpose/src/index.ts
@@ -25,7 +25,7 @@ import {Coords3D, HandPipeline, Prediction} from './pipeline';
 // Load the bounding box detector model.
 async function loadHandDetectorModel() {
   const HANDDETECT_MODEL_PATH =
-      'https://tfhub.dev/tensorflow/tfjs-model/handdetector/1/default/1';
+      'https://tfhub.dev/mediapipe/tfjs-model/handdetector/1/default/1';
   return tfconv.loadGraphModel(HANDDETECT_MODEL_PATH, {fromTFHub: true});
 }
 
@@ -35,7 +35,7 @@ const MESH_MODEL_INPUT_HEIGHT = 256;
 // Load the mesh detector model.
 async function loadHandPoseModel() {
   const HANDPOSE_MODEL_PATH =
-      'https://tfhub.dev/tensorflow/tfjs-model/handskeleton/1/default/1';
+      'https://tfhub.dev/mediapipe/tfjs-model/handskeleton/1/default/1';
   return tfconv.loadGraphModel(HANDPOSE_MODEL_PATH, {fromTFHub: true});
 }
 
@@ -45,7 +45,7 @@ async function loadHandPoseModel() {
 async function loadAnchors() {
   return tf.util
       .fetch(
-          'https://tfhub.dev/tensorflow/tfjs-model/handskeleton/1/default/1/anchors.json?tfjs-format=file')
+          'https://tfhub.dev/mediapipe/tfjs-model/handskeleton/1/default/1/anchors.json?tfjs-format=file')
       .then(d => d.json());
 }
 


### PR DESCRIPTION
I'll run `yarn` in the demo after publishing 0.0.3 of handpose to correct its lock file.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/419)
<!-- Reviewable:end -->
