### PR TITLE
Trim the context string early, to avoid string indices potentially getting corrupted

### DIFF
--- a/qna/src/question_and_answer.ts
+++ b/qna/src/question_and_answer.ts
@@ -110,7 +110,7 @@ class QuestionAndAnswerImpl implements QuestionAndAnswer {
           `The length of question token exceeds the limit (${maxQueryLen}).`);
     }
 
-    const origTokens = this.tokenizer.processInput(context.trim());
+    const origTokens = this.tokenizer.processInput(context);
     const tokenToOrigIndex = [];
     const allDocTokens = [];
     for (let i = 0; i < origTokens.length; i++) {
@@ -207,6 +207,8 @@ class QuestionAndAnswerImpl implements QuestionAndAnswer {
           'The input to findAnswers call is null, ' +
           'please pass a string as input.');
     }
+    // it is better to trim early, otherwise string indices can be wrong later on
+    context = context.trim();
 
     const features =
         this.process(question, context, MAX_QUERY_LEN, MAX_SEQ_LEN);


### PR DESCRIPTION
Proposal to trim the context string early, because not doing so can potentially result in string indices becoming unaligned if the initial string starts with empty new lines. (I haven't checked conclusively, but honestly I don't see a good reason not to do this early anyway)