### PR TITLE
[handpose] Make getBoundingBoxes async.

### DIFF
--- a/handpose/src/hand.ts
+++ b/handpose/src/hand.ts
@@ -84,7 +84,6 @@ export class HandDetector {
 
   private async getBoundingBoxes(input: tf.Tensor4D):
       Promise<HandDetectorPrediction> {
-    // const normalizedInput = tf.mul(tf.sub(input, 0.5), 2);
     const normalizedInput = tf.tidy(() => tf.mul(tf.sub(input, 0.5), 2));
 
     // Currently tfjs-core does not pack depthwiseConv because it fails for

--- a/handpose/src/pipeline.ts
+++ b/handpose/src/pipeline.ts
@@ -159,7 +159,7 @@ export class HandPipeline {
     const useFreshBox = this.shouldUpdateRegionsOfInterest();
     if (useFreshBox === true) {
       const boundingBoxPrediction =
-          this.boundingBoxDetector.estimateHandBounds(image);
+          await this.boundingBoxDetector.estimateHandBounds(image);
       if (boundingBoxPrediction === null) {
         image.dispose();
         this.regionsOfInterest = [];


### PR DESCRIPTION
This paves the way for adding WebGPU support to handpose. 

Non-max suppression requires all inputs to reside in the CPU by calling `dataSync`, however synchronous read is not available in WebGPU. @axinging is working on a patch to handpose that asynchronously moves inputs to the CPU for NMS. Making `getBoundingBoxes` asynchronous unblocks his work. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/434)
<!-- Reviewable:end -->
