### PR TITLE
Fixed typo in demo_util.js comments

### DIFF
--- a/posenet/demos/demo_util.js
+++ b/posenet/demos/demo_util.js
@@ -141,7 +141,7 @@ export function drawBoundingBox(keypoints, ctx) {
 }
 
 /**
- * Converts an arary of pixel data into an ImageData object
+ * Converts an array of pixel data into an ImageData object
  */
 export async function renderToCanvas(a, ctx) {
   const [height, width] = a.shape;


### PR DESCRIPTION
Fixed a small typo 'arary' by changing to it to 'array'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/441)
<!-- Reviewable:end -->
