### PR TITLE
Add return type overloads for estimateFaces

### DIFF
--- a/facemesh/src/index.ts
+++ b/facemesh/src/index.ts
@@ -27,7 +27,7 @@ const FACEMESH_GRAPHMODEL_PATH =
 const MESH_MODEL_INPUT_WIDTH = 192;
 const MESH_MODEL_INPUT_HEIGHT = 192;
 
-interface AnnotatedPredictionValues {
+export interface AnnotatedPredictionValues {
   /** Probability of the face detection. */
   faceInViewConfidence: number;
   boundingBox: {
@@ -44,7 +44,7 @@ interface AnnotatedPredictionValues {
   annotations?: {[key: string]: Array<[number, number, number]>};
 }
 
-interface AnnotatedPredictionTensors {
+export interface AnnotatedPredictionTensors {
   faceInViewConfidence: number;
   boundingBox: {topLeft: tf.Tensor1D, bottomRight: tf.Tensor1D};
   mesh: tf.Tensor2D;
@@ -193,6 +193,16 @@ export class FaceMesh {
    *
    * @return An array of AnnotatedPrediction objects.
    */
+  async estimateFaces(
+      input: tf.Tensor3D|ImageData|HTMLVideoElement|HTMLImageElement|
+      HTMLCanvasElement,
+      returnTensors: true,
+      flipHorizontal = false): Promise<AnnotatedPredictionTensors[]>;
+  async estimateFaces(
+      input: tf.Tensor3D|ImageData|HTMLVideoElement|HTMLImageElement|
+      HTMLCanvasElement,
+      returnTensors: false,
+      flipHorizontal = false): Promise<AnnotatedPredictionValues[]>;
   async estimateFaces(
       input: tf.Tensor3D|ImageData|HTMLVideoElement|HTMLImageElement|
       HTMLCanvasElement,


### PR DESCRIPTION
This improves the ergonomics when a constant true/false value is passed to the function. TypeScript will choose the correct return type accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/449)
<!-- Reviewable:end -->
