### PR TITLE
[facemesh] Correctly work if webgl backend is not registred

### DIFF
--- a/facemesh/src/index.ts
+++ b/facemesh/src/index.ts
@@ -220,11 +220,15 @@ export class FaceMesh {
     // very large inputs (https://github.com/tensorflow/tfjs/issues/1652).
     // TODO(annxingyuan): call tf.enablePackedDepthwiseConv when available
     // (https://github.com/tensorflow/tfjs/issues/2821)
-    const savedWebglPackDepthwiseConvFlag =
-        tf.env().get('WEBGL_PACK_DEPTHWISECONV');
-    tf.env().set('WEBGL_PACK_DEPTHWISECONV', true);
+    let savedWebglPackDepthwiseConvFlag;
+    if (tf.getBackend() === 'webgl') {
+      savedWebglPackDepthwiseConvFlag = tf.env().get('WEBGL_PACK_DEPTHWISECONV');
+      tf.env().set('WEBGL_PACK_DEPTHWISECONV', true);
+    }
     const predictions = await this.pipeline.predict(image);
-    tf.env().set('WEBGL_PACK_DEPTHWISECONV', savedWebglPackDepthwiseConvFlag);
+    if (tf.getBackend() === 'webgl') {
+      tf.env().set('WEBGL_PACK_DEPTHWISECONV', savedWebglPackDepthwiseConvFlag);
+    }
 
     image.dispose();
 


### PR DESCRIPTION
env.get(WEBGL_PACK_DEPTHWISECONV) throws an exception if webgl backend
is not registred. This makes facemesh impossible to use without shipping
this backend, even when the aplication intends to use other backends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/468)
<!-- Reviewable:end -->
