### PR TITLE
iOS safari shader compilation issue

### DIFF
--- a/handpose/src/rotate_gpu.ts
+++ b/handpose/src/rotate_gpu.ts
@@ -58,8 +58,8 @@ export function rotate(
         int x = coords[2];
         int y = coords[1];
         int coordX = int(float(x - ${centerX}) * ${cosFactor} -
-          float(y - ${centerY}) * ${sinFactor});
-        int coordY = int(float(x - ${centerX}) * ${sinFactor} +
+          float(y - ${centerY}) * float(${sinFactor}));
+        int coordY = int(float(x - ${centerX}) * float(${sinFactor}) +
           float(y - ${centerY}) * ${cosFactor});
         coordX = int(coordX + ${centerX});
         coordY = int(coordY + ${centerY});

--- a/handpose/src/rotate_gpu.ts
+++ b/handpose/src/rotate_gpu.ts
@@ -57,10 +57,10 @@ export function rotate(
         ivec4 coords = getOutputCoords();
         int x = coords[2];
         int y = coords[1];
-        int coordX = int(float(x - ${centerX}) * ${cosFactor} -
+        int coordX = int(float(x - ${centerX}) * float(${cosFactor}) -
           float(y - ${centerY}) * float(${sinFactor}));
         int coordY = int(float(x - ${centerX}) * float(${sinFactor}) +
-          float(y - ${centerY}) * ${cosFactor});
+          float(y - ${centerY}) * float(${cosFactor}));
         coordX = int(coordX + ${centerX});
         coordY = int(coordY + ${centerY});
 


### PR DESCRIPTION
It appears that sinFactor and cosFactor can be output into the shader as an integer (-1 or 1).  On iOS (13.4.1) safari this causes a shader compilation issue.  Every other browser I've tried has dealt with it just fine.

I'm not sure this is the best fix but I can confirm it does resolve the issue in iOS (13.4.1) safari.

Below is the relevant parts of the safari console log:

```
[Log] ERROR: 0:159: '*' : wrong operand types - no operation '*' exists that takes a left-hand operand of type 'highp float' and a right operand of type 'const int' (or there is no acceptable conversion)

int coordX = int(float(x - 424) * 6.123233995736766e-17 - float(y - 188) * -1);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/471)
<!-- Reviewable:end -->
