### PR TITLE
Support passing model URL as  parameters

### DIFF
--- a/handpose/src/index.ts
+++ b/handpose/src/index.ts
@@ -23,29 +23,25 @@ import {MESH_ANNOTATIONS} from './keypoints';
 import {Coords3D, HandPipeline, Prediction} from './pipeline';
 
 // Load the bounding box detector model.
-async function loadHandDetectorModel() {
-  const HANDDETECT_MODEL_PATH =
-      'https://tfhub.dev/mediapipe/tfjs-model/handdetector/1/default/1';
-  return tfconv.loadGraphModel(HANDDETECT_MODEL_PATH, {fromTFHub: true});
+async function loadHandDetectorModel(handdetectModelURL:string) {
+  return tfconv.loadGraphModel(handdetectModelURL, {fromTFHub: true});
 }
 
 const MESH_MODEL_INPUT_WIDTH = 256;
 const MESH_MODEL_INPUT_HEIGHT = 256;
 
 // Load the mesh detector model.
-async function loadHandPoseModel() {
-  const HANDPOSE_MODEL_PATH =
-      'https://tfhub.dev/mediapipe/tfjs-model/handskeleton/1/default/1';
-  return tfconv.loadGraphModel(HANDPOSE_MODEL_PATH, {fromTFHub: true});
+async function loadHandPoseModel(handposeModelURL:string) {
+  return tfconv.loadGraphModel(handposeModelURL, {fromTFHub: true});
 }
 
 // In single shot detector pipelines, the output space is discretized into a set
 // of bounding boxes, each of which is assigned a score during prediction. The
 // anchors define the coordinates of these boxes.
-async function loadAnchors() {
+async function loadAnchors(anchorsURL:string) {
   return tf.util
       .fetch(
-          'https://tfhub.dev/mediapipe/tfjs-model/handskeleton/1/default/1/anchors.json?tfjs-format=file')
+          anchorsURL)
       .then(d => d.json());
 }
 
@@ -72,10 +68,13 @@ export async function load({
   maxContinuousChecks = Infinity,
   detectionConfidence = 0.8,
   iouThreshold = 0.3,
-  scoreThreshold = 0.5
+  scoreThreshold = 0.5,
+  handdetectModelURL = 'https://tfhub.dev/mediapipe/tfjs-model/handdetector/1/default/1',
+  handposeModelURL = 'https://tfhub.dev/mediapipe/tfjs-model/handskeleton/1/default/1',
+  anchorsURL = 'https://tfhub.dev/mediapipe/tfjs-model/handskeleton/1/default/1/anchors.json?tfjs-format=file'
 } = {}): Promise<HandPose> {
   const [ANCHORS, handDetectorModel, handPoseModel] = await Promise.all(
-      [loadAnchors(), loadHandDetectorModel(), loadHandPoseModel()]);
+      [loadAnchors(anchorsURL), loadHandDetectorModel(handdetectModelURL), loadHandPoseModel(handposeModelURL)]);
 
   const detector = new HandDetector(
       handDetectorModel, MESH_MODEL_INPUT_WIDTH, MESH_MODEL_INPUT_HEIGHT,

--- a/handpose/src/index.ts
+++ b/handpose/src/index.ts
@@ -63,6 +63,9 @@ interface AnnotatedPrediction extends Prediction {
  * Defaults to 0.3.
  * - `scoreThreshold` A threshold for deciding when to remove boxes based
  * on score in non-maximum suppression. Defaults to 0.75.
+ * - `handdetectModelURL` Specify URL of handdetect model. Defaults to tfhub.dev.
+ * - `handposeModelURL` Specify URL of handdetect model. Defaults to tfhub.dev.
+ * - `anchorsURL` Specify URL of handdetect model's anchors file. Defaults to tfhub.dev.
  */
 export async function load({
   maxContinuousChecks = Infinity,


### PR DESCRIPTION
Sometimes we need store the models in an inner-network and should customized the URL of models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/488)
<!-- Reviewable:end -->
