### PR TITLE
[toxicity] ts: make toxicityLabels parameter optional

### DIFF
--- a/toxicity/src/index.ts
+++ b/toxicity/src/index.ts
@@ -30,7 +30,7 @@ declare interface ModelInputs extends tf.NamedTensorMap {
  *
  * @param threshold A prediction is considered valid only if its confidence
  * exceeds the threshold. Defaults to 0.85.
- * @param toxicityLabels An array of strings indicating which types of toxicity
+ * @param [toxicityLabels=[]] An array of strings indicating which types of toxicity
  * to detect. Labels must be one of `toxicity` | `severe_toxicity` |
  * `identity_attack` | `insult` | `threat` | `sexual_explicit` | `obscene`.
  * Defaults to all labels.

--- a/toxicity/src/index.ts
+++ b/toxicity/src/index.ts
@@ -35,7 +35,7 @@ declare interface ModelInputs extends tf.NamedTensorMap {
  * `identity_attack` | `insult` | `threat` | `sexual_explicit` | `obscene`.
  * Defaults to all labels.
  */
-export async function load(threshold: number, toxicityLabels: string[]) {
+export async function load(threshold: number, toxicityLabels?: string[]) {
   const model = new ToxicityClassifier(threshold, toxicityLabels);
   await model.load();
   return model;


### PR DESCRIPTION
The docs state that the parameter defaults to all labels:

```js
 * @param toxicityLabels An array of strings indicating which types of toxicity
 * to detect. Labels must be one of `toxicity` | `severe_toxicity` |
 * `identity_attack` | `insult` | `threat` | `sexual_explicit` | `obscene`.
 * Defaults to all labels.
```

However in the TypeScript definition is marked as non-optional:

```js
export async function load(threshold: number, toxicityLabels: string[]) 
```

This PR makes the parameter optional

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/515)
<!-- Reviewable:end -->
