### PR TITLE
Bug fix: tfjs treats HTMLVideoElement as 0*0 size by default

### DIFF
--- a/body-pix/src/util.ts
+++ b/body-pix/src/util.ts
@@ -35,8 +35,10 @@ function getSizeFromImageLikeElement(input: HTMLImageElement|
 }
 
 function getSizeFromVideoElement(input: HTMLVideoElement): [number, number] {
-  if (input.height != null && input.width != null) {
+  if (input.hasAttribute('height') && input.hasAttribute('width')) {
     // Prioritizes user specified height and width.
+    // We can't test the .height and .width properties directly,
+    // because they evaluate to 0 if unset.
     return [input.height, input.width];
   } else {
     return [input.videoHeight, input.videoWidth];


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/523)
<!-- Reviewable:end -->
