### PR TITLE
update toxicity readme to import tfjs

### DIFF
--- a/toxicity/README.md
+++ b/toxicity/README.md
@@ -23,6 +23,7 @@ Using `npm`:
 To import in npm:
 
 ```js
+require('@tensorflow/tfjs');
 const toxicity = require('@tensorflow-models/toxicity');
 ```
 


### PR DESCRIPTION
Update toxicity readme to import tfjs in the commonjs snippet. Without this you get no backend found error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/525)
<!-- Reviewable:end -->
