### PR TITLE
blazeface.load() take a model URL

### DIFF
--- a/blazeface/src/index.ts
+++ b/blazeface/src/index.ts
@@ -32,16 +32,19 @@ const BLAZEFACE_MODEL_URL =
  * much.
  *  `scoreThreshold` The threshold for deciding when to remove boxes based
  * on score.
+ *  `blazeModelUrl` Optional param for specifying a custom blaze model url or
+ * a `tf.io.IOHandler` object.
  */
 export async function load({
   maxFaces = 10,
   inputWidth = 128,
   inputHeight = 128,
   iouThreshold = 0.3,
-  scoreThreshold = 0.75
+  scoreThreshold = 0.75,
+  blazeModelUrl = BLAZEFACE_MODEL_URL,
 } = {}): Promise<BlazeFaceModel> {
   const blazeface =
-      await tfconv.loadGraphModel(BLAZEFACE_MODEL_URL, {fromTFHub: true});
+      await tfconv.loadGraphModel(blazeModelUrl, {fromTFHub: true});
 
   const model = new BlazeFaceModel(
       blazeface, inputWidth, inputHeight, maxFaces, iouThreshold,


### PR DESCRIPTION
For commercial projects, the models generally need to be hosted on a trusted.& controlled site with a shared domain as the app.  Adding a URL parameter lets projects store the model files on their own public servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/529)
<!-- Reviewable:end -->
