### PR TITLE
[blazeface] Blazeface.load() takes optional modelURL param

### DIFF
--- a/blazeface/src/index.ts
+++ b/blazeface/src/index.ts
@@ -32,16 +32,19 @@ const BLAZEFACE_MODEL_URL =
  * much.
  *  `scoreThreshold` The threshold for deciding when to remove boxes based
  * on score.
+ *  `blazeModelUrl` Optional param for specifying a custom blaze model url or
+ * a `tf.io.IOHandler` object.
  */
 export async function load({
   maxFaces = 10,
   inputWidth = 128,
   inputHeight = 128,
   iouThreshold = 0.3,
-  scoreThreshold = 0.75
+  scoreThreshold = 0.75,
+  blazeModelUrl = BLAZEFACE_MODEL_URL,
 } = {}): Promise<BlazeFaceModel> {
   const blazeface =
-      await tfconv.loadGraphModel(BLAZEFACE_MODEL_URL, {fromTFHub: true});
+      await tfconv.loadGraphModel(blazeModelUrl, {fromTFHub: true});
 
   const model = new BlazeFaceModel(
       blazeface, inputWidth, inputHeight, maxFaces, iouThreshold,

--- a/blazeface/src/index.ts
+++ b/blazeface/src/index.ts
@@ -32,19 +32,16 @@ const BLAZEFACE_MODEL_URL =
  * much.
  *  `scoreThreshold` The threshold for deciding when to remove boxes based
  * on score.
- *  `blazeModelUrl` Optional param for specifying a custom blaze model url or
- * a `tf.io.IOHandler` object.
  */
 export async function load({
   maxFaces = 10,
   inputWidth = 128,
   inputHeight = 128,
   iouThreshold = 0.3,
-  scoreThreshold = 0.75,
-  blazeModelUrl = BLAZEFACE_MODEL_URL,
+  scoreThreshold = 0.75
 } = {}): Promise<BlazeFaceModel> {
   const blazeface =
-      await tfconv.loadGraphModel(blazeModelUrl, {fromTFHub: true});
+      await tfconv.loadGraphModel(BLAZEFACE_MODEL_URL, {fromTFHub: true});
 
   const model = new BlazeFaceModel(
       blazeface, inputWidth, inputHeight, maxFaces, iouThreshold,


### PR DESCRIPTION
`mediapipe-facemesh` depends on `blazeface` for face detection.
However, blazeface does not allow loading models from non-tfhub sources. This is problematic for commercial users who do not want hard dependencies on other sites at web runtime.
This fix will allow [face-landmarks-detection](https://github.com/tensorflow/tfjs-models/blob/master/face-landmarks-detection/src/mediapipe-facemesh/index.ts#L153) to load blazeface from a custom URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/534)
<!-- Reviewable:end -->
