### PR TITLE
[BodyPix] Fix image rendering only at natural scale in output renderer utility

### DIFF
--- a/body-pix/src/output_rendering_util.ts
+++ b/body-pix/src/output_rendering_util.ts
@@ -363,7 +363,7 @@ export function drawMask(
     flipCanvasHorizontal(canvas);
   }
 
-  ctx.drawImage(image, 0, 0);
+  ctx.drawImage(image, 0, 0, width, height);
 
   ctx.globalAlpha = maskOpacity;
   if (maskImage) {


### PR DESCRIPTION
Hey guys, awesome project. Thanks for making it available.

This is a fix for the output renderer utility whose `drawMask` is currently ignoring scaling factors while writing the image to the canvas element, resulting in a misalignment between the image and the mask that's supposed to be superimposed on it. See https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage#Understanding_source_element_size

Below is an example of the issue from my test bench app, before and after recompiling the library with the fix:

Before:
<img width="813" alt="Screen Shot 2020-11-22 at 9 15 16 AM" src="https://user-images.githubusercontent.com/3229134/99907891-19dbe700-2ca5-11eb-9ceb-56366d2bcef4.png">

After:
<img width="812" alt="Screen Shot 2020-11-22 at 9 14 05 AM" src="https://user-images.githubusercontent.com/3229134/99907898-23fde580-2ca5-11eb-9138-7a498283c819.png">

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/537)
<!-- Reviewable:end -->
