### PR TITLE
redirect to cpu only for webgl backend

### DIFF
--- a/coco-ssd/src/index.ts
+++ b/coco-ssd/src/index.ts
@@ -139,7 +139,9 @@ export class ObjectDetection {
 
     const prevBackend = tf.getBackend();
     // run post process in cpu
-    tf.setBackend('cpu');
+    if (tf.getBackend() === 'webgl') {
+      tf.setBackend('cpu');
+    }
     const indexTensor = tf.tidy(() => {
       const boxes2 =
           tf.tensor2d(boxes, [result[1].shape[1], result[1].shape[3]]);
@@ -151,7 +153,9 @@ export class ObjectDetection {
     indexTensor.dispose();
 
     // restore previous backend
-    tf.setBackend(prevBackend);
+    if (prevBackend !== tf.getBackend()) {
+      tf.setBackend(prevBackend);
+    }
 
     return this.buildDetectedObjects(
         width, height, boxes, maxScores, indexes, classes);


### PR DESCRIPTION
fixes https://github.com/tensorflow/tfjs/issues/4234

The warning message is shown when redirect the post-processing to cpu backend, this should only be enabled for webgl backend, given that node and wasm backend would be faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/538)
<!-- Reviewable:end -->
