### PR TITLE
update coco-ssd to 2.2.0

### DIFF
--- a/coco-ssd/package.json
+++ b/coco-ssd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/coco-ssd",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Object detection model (coco-ssd) in TensorFlow.js",
   "main": "dist/coco-ssd.node.js",
   "unpkg": "dist/coco-ssd.min.js",

--- a/coco-ssd/src/version.ts
+++ b/coco-ssd/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '2.1.0';
+const version = '2.2.0';
 export {version};


### PR DESCRIPTION
ref https://github.com/tensorflow/tfjs/issues/4234

The warning message is shown when redirect the post-processing to cpu backend, this should only be enabled for webgl backend, given that node and wasm backend would be faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/540)
<!-- Reviewable:end -->
