### PR TITLE
bump version to 2.2.1

### DIFF
--- a/coco-ssd/package.json
+++ b/coco-ssd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/coco-ssd",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Object detection model (coco-ssd) in TensorFlow.js",
   "main": "dist/coco-ssd.node.js",
   "unpkg": "dist/coco-ssd.min.js",

--- a/coco-ssd/src/version.ts
+++ b/coco-ssd/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '2.2.0';
+const version = '2.2.1';
 export {version};


### PR DESCRIPTION
Somehow the published npm package failed to be loaded in the demo, republishing coco-ssd with a new version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/541)
<!-- Reviewable:end -->
