### PR TITLE
[facemesh] yarn command typo

### DIFF
--- a/facemesh/README.md
+++ b/facemesh/README.md
@@ -41,7 +41,7 @@ Using `yarn`:
 
     $ yarn add @tensorflow-models/facemesh
 
-    $ yarn add @tensorflow/tfjs-core, @tensorflow/tfjs-converter
+    $ yarn add @tensorflow/tfjs-core @tensorflow/tfjs-converter
     $ yarn add @tensorflow/tfjs-backend-wasm # or @tensorflow/tfjs-backend-webgl
 
 ## Usage


### PR DESCRIPTION
Remove a comma from facemesh README to prevent an error when copy pasting yarn commands

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/544)
<!-- Reviewable:end -->
