### PR TITLE
Update README.md

### DIFF
--- a/deeplab/demo/README.md
+++ b/deeplab/demo/README.md
@@ -4,6 +4,8 @@ This demo allows you to try out semantic segmentation on a couple of preset imag
 
 ## Setup
 
+Run `yarn` in the root and 'deeplab' folder to install tsc types.
+
 Run `yarn build-npm` in the 'deeplab' folder.
 
 Change the directory to the `demo` folder:


### PR DESCRIPTION
The `yarn build-npm` step will fail without typescript types installed. This PR adds a step to install them.