### PR TITLE
Adding a parameter to control the update behaviour of face bounding boxes from previous predictions on face-landmarks-detection

### DIFF
--- a/face-landmarks-detection/src/index.ts
+++ b/face-landmarks-detection/src/index.ts
@@ -47,6 +47,8 @@ export enum SupportedPackages {
  * Defaults to 0.3.
  *  - `scoreThreshold` A threshold for deciding when to remove boxes based
  * on score in non-maximum suppression. Defaults to 0.75.
+ *  - `boundingBoxUpdateRoiIouThreshold` A threshold to decide how much does
+ *  face detector bounding boxes overlap to be updated. Defaults to 0.25.
  *  - `shouldLoadIrisModel` Whether to also load the iris detection model.
  * Defaults to true.
  */

--- a/face-landmarks-detection/src/mediapipe-facemesh/index.ts
+++ b/face-landmarks-detection/src/mediapipe-facemesh/index.ts
@@ -100,6 +100,8 @@ export type AnnotatedPrediction =
  * Defaults to 0.3.
  *  - `scoreThreshold` A threshold for deciding when to remove boxes based
  * on score in non-maximum suppression. Defaults to 0.75.
+ *  - `boundingBoxUpdateRoiIouThreshold` A threshold to decide how much does
+ *  face detector bounding boxes overlap to be updated. Defaults to 0.25.
  *  - `shouldLoadIrisModel` Whether to also load the iris detection model.
  * Defaults to true.
  *  - `modelUrl` Optional param for specifying a custom facemesh model url or
@@ -115,6 +117,7 @@ export async function load(config: {
   maxFaces?: number,
   iouThreshold?: number,
   scoreThreshold?: number,
+  boundingBoxUpdateRoiIouThreshold?: number,
   shouldLoadIrisModel?: boolean,
   modelUrl?: string|tf.io.IOHandler,
   detectorModelUrl?: string|tf.io.IOHandler,
@@ -126,6 +129,7 @@ export async function load(config: {
     maxFaces = 10,
     iouThreshold = 0.3,
     scoreThreshold = 0.75,
+    boundingBoxUpdateRoiIouThreshold = 0.25,
     shouldLoadIrisModel = true,
     modelUrl,
     detectorModelUrl,
@@ -152,7 +156,7 @@ export async function load(config: {
 
   const faceMesh = new FaceMesh(
       models[0], models[1], maxContinuousChecks, detectionConfidence, maxFaces,
-      shouldLoadIrisModel ? models[2] : null);
+      shouldLoadIrisModel ? models[2] : null, boundingBoxUpdateRoiIouThreshold);
   return faceMesh;
 }
 
@@ -256,10 +260,12 @@ class FaceMesh implements MediaPipeFaceMesh {
   constructor(
       blazeFace: blazeface.BlazeFaceModel, blazeMeshModel: tfconv.GraphModel,
       maxContinuousChecks: number, detectionConfidence: number,
-      maxFaces: number, irisModel: tfconv.GraphModel|null) {
+      maxFaces: number, irisModel: tfconv.GraphModel|null,
+      boundingBoxUpdateRoiIouThreshold: number) {
     this.pipeline = new Pipeline(
         blazeFace, blazeMeshModel, MESH_MODEL_INPUT_WIDTH,
-        MESH_MODEL_INPUT_HEIGHT, maxContinuousChecks, maxFaces, irisModel);
+        MESH_MODEL_INPUT_HEIGHT, maxContinuousChecks, maxFaces, irisModel,
+        boundingBoxUpdateRoiIouThreshold);
 
     this.detectionConfidence = detectionConfidence;
   }

--- a/face-landmarks-detection/src/mediapipe-facemesh/pipeline.ts
+++ b/face-landmarks-detection/src/mediapipe-facemesh/pipeline.ts
@@ -31,7 +31,6 @@ export type Prediction = {
 };
 
 const LANDMARKS_COUNT = 468;
-const UPDATE_REGION_OF_INTEREST_IOU_THRESHOLD = 0.25;
 
 const MESH_MOUTH_INDEX = 13;
 const MESH_KEYPOINTS_LINE_OF_SYMMETRY_INDICES =
@@ -100,6 +99,7 @@ function replaceRawCoordinates(
 export class Pipeline {
   // MediaPipe model for detecting facial bounding boxes.
   private boundingBoxDetector: blazeface.BlazeFaceModel;
+  private boundingBoxUpdateRoiIouThreshold: number;
   // MediaPipe model for detecting facial mesh.
   private meshDetector: tfconv.GraphModel;
 
@@ -118,8 +118,10 @@ export class Pipeline {
       boundingBoxDetector: blazeface.BlazeFaceModel,
       meshDetector: tfconv.GraphModel, meshWidth: number, meshHeight: number,
       maxContinuousChecks: number, maxFaces: number,
-      irisModel: tfconv.GraphModel|null) {
+      irisModel: tfconv.GraphModel|null,
+      boundingBoxUpdateRoiIouThreshold: number) {
     this.boundingBoxDetector = boundingBoxDetector;
+    this.boundingBoxUpdateRoiIouThreshold = boundingBoxUpdateRoiIouThreshold;
     this.meshDetector = meshDetector;
     this.irisModel = irisModel;
     this.meshWidth = meshWidth;
@@ -451,7 +453,7 @@ export class Pipeline {
         iou = intersection / (boxArea + previousBoxArea - intersection);
       }
 
-      if (iou < UPDATE_REGION_OF_INTEREST_IOU_THRESHOLD) {
+      if (iou < this.boundingBoxUpdateRoiIouThreshold) {
         this.regionsOfInterest[i] = box;
       }
     }


### PR DESCRIPTION
Added `boundingBoxUpdateRoiIouThreshold` param to the load model function, which allows to decide how much does face detector bounding boxes overlap to be updated. This means that the model could be feed with images of different sizes and still work without needing to [force the model to invalidate the cache of face bounding boxes](https://github.com/tensorflow/tfjs/issues/4668#issue-805720307).

This change was suggested on the issue: [face-landmarks-detection model caching bounding boxes from previous predictions](https://github.com/tensorflow/tfjs/issues/4668). The local tests were successful as can be seen on these images used on the original issue: [facelandmarks-detection wrong when image dimensions change](https://github.com/tensorflow/tfjs/issues/4131).

```
    model = await faceLandmarksDetection.load(
      faceLandmarksDetection.SupportedPackages.mediapipeFacemesh,
      {
        maxContinuousChecks: 0,
        boundingBoxUpdateRoiIouThreshold: 1.0,  // update *all* face bounding boxes
      }
    );
    ...
    let predictions = await model.estimateFaces({
        input: imageAsTensor3D
      }
    );
    // draw landmarks and immediately predict another image of different size
    ...
    let predictions2 = await model.estimateFaces({
        input: image2AsTensor3D
      }
    );
    // draw landmarks
```

![image](https://user-images.githubusercontent.com/3931964/107864351-66107080-6e29-11eb-8a1e-e6e5914a0791.png)

And this will be the result if using the default value of `0.25` for `boundingBoxUpdateRoiIouThreshold`:

![image](https://user-images.githubusercontent.com/3931964/107864454-36ae3380-6e2a-11eb-9c69-ed66da890417.png)

**Note**. The build for face-landmarks-detection will fail in this branch because it depends on a published version of blazeface, which does not have modelUrl parameter yet.