### PR TITLE
Bump posenet version number

### DIFF
--- a/posenet/package.json
+++ b/posenet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow-models/posenet",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Pretrained PoseNet model in TensorFlow.js",
   "main": "dist/index.js",
   "jsnext:main": "dist/posenet.esm.js",


### PR DESCRIPTION
This is for https://github.com/tensorflow/tfjs/issues/4653. Looks like we didn't publish the npm package after updating posenet model to 3.0. I plan to publish this new minor version after this PR is merged.