### PR TITLE
[posedetection] PoseNet single pose migration

### DIFF
--- a/pose-detection/run_tests.ts
+++ b/pose-detection/run_tests.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// Use the CPU backend for running tests.
+import '@tensorflow/tfjs-backend-cpu';
+// tslint:disable-next-line:no-imports-from-dist
+import * as jasmine_util from '@tensorflow/tfjs-core/dist/jasmine_util';
+
+// tslint:disable-next-line:no-require-imports
+const jasmineCtor = require('jasmine');
+// tslint:disable-next-line:no-require-imports
+
+Error.stackTraceLimit = Infinity;
+
+process.on('unhandledRejection', e => {
+  throw e;
+});
+
+jasmine_util.setTestEnvs(
+    [{name: 'test-posedetection', backendName: 'cpu', flags: {}}]);
+
+const unitTests = 'src/**/*_test.ts';
+
+const runner = new jasmineCtor();
+runner.loadConfig({spec_files: [unitTests], random: false});
+runner.execute();

--- a/pose-detection/src/calculators/convert_image_to_tensor.ts
+++ b/pose-detection/src/calculators/convert_image_to_tensor.ts
@@ -28,7 +28,9 @@ import {Rect} from './interfaces/shape_interfaces';
  * @param config
  *      inputResolution: The target height and width.
  *      keepAspectRatio?: Whether target tensor should keep aspect ratio.
- * @param normRect
+ * @param normRect A normalized rectangle, representing the subarea to crop from
+ *      the image. If normRect is provided, the returned image tensor represents
+ *      the subarea.
  */
 export function convertImageToTensor(
     image: PoseDetectorInput, config: ImageToTensorConfig,

--- a/pose-detection/src/calculators/convert_image_to_tensor.ts
+++ b/pose-detection/src/calculators/convert_image_to_tensor.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import * as tf from '@tensorflow/tfjs-core';
+import {PoseDetectorInput} from '../types';
+import {getImageSize, getProjectiveTransformMatrix, getRoi, padRoi, toImageTensor} from './image_utils';
+import {Padding} from './interfaces/common_interfaces';
+import {ImageToTensorConfig} from './interfaces/config_interfaces';
+import {Rect} from './interfaces/shape_interfaces';
+
+/**
+ * Convert an image or part of it to an image tensor.
+ *
+ * @param image An image, video frame or image tensor.
+ * @param config
+ *      inputResolution: The target height and width.
+ *      keepAspectRatio?: Whether target tensor should keep aspect ratio.
+ * @param normRect
+ */
+export function convertImageToTensor(
+    image: PoseDetectorInput, config: ImageToTensorConfig,
+    normRect?: Rect): {imageTensor: tf.Tensor4D, padding: Padding} {
+  const {inputResolution, keepAspectRatio} = config;
+
+  const imageSize = getImageSize(image);
+  const roi = getRoi(imageSize, normRect);
+  const padding = padRoi(roi, inputResolution, keepAspectRatio);
+
+  const imageTensor = tf.tidy(() => {
+    const $image = toImageTensor(image);
+
+    const transformMatrix = tf.tensor2d(
+        getProjectiveTransformMatrix(roi, imageSize, false, inputResolution),
+        [1, 8]);
+
+    const imageTransformed = tf.image.transform(
+        tf.expandDims(tf.cast($image, 'float32')) as tf.Tensor4D,
+        transformMatrix, 'bilinear', 'constant', 0,
+        [inputResolution.height, inputResolution.width]);
+
+    return imageTransformed;
+  });
+
+  return {imageTensor, padding};
+}

--- a/pose-detection/src/calculators/convert_image_to_tensor.ts
+++ b/pose-detection/src/calculators/convert_image_to_tensor.ts
@@ -37,6 +37,8 @@ export function convertImageToTensor(
     normRect?: Rect): {imageTensor: tf.Tensor4D, padding: Padding} {
   const {inputResolution, keepAspectRatio} = config;
 
+  // Ref:
+  // https://github.com/google/mediapipe/blob/master/mediapipe/calculators/tensor/image_to_tensor_calculator.cc
   const imageSize = getImageSize(image);
   const roi = getRoi(imageSize, normRect);
   const padding = padRoi(roi, inputResolution, keepAspectRatio);

--- a/pose-detection/src/calculators/image_utils.ts
+++ b/pose-detection/src/calculators/image_utils.ts
@@ -171,6 +171,8 @@ export function getProjectiveTransformMatrix(
     [number, number, number, number, number, number, number, number] {
   validateSize(inputResolution, 'inputResolution');
 
+  // Ref:
+  // https://github.com/google/mediapipe/blob/master/mediapipe/calculators/tensor/image_to_tensor_utils.cc
   // The resulting matrix is multiplication of below matrices:
   // M = postScaleMatrix * translateMatrix * rotateMatrix * flipMatrix *
   //     scaleMatrix * initialTranslateMatrix

--- a/pose-detection/src/calculators/image_utils.ts
+++ b/pose-detection/src/calculators/image_utils.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import * as tf from '@tensorflow/tfjs-core';
+import {InputResolution, PoseDetectorInput} from '../types';
+import {ImageSize, Padding, ValueTransform} from './interfaces/common_interfaces';
+import {Rect} from './interfaces/shape_interfaces';
+
+export function getImageSize(input: PoseDetectorInput): ImageSize {
+  if (input instanceof tf.Tensor) {
+    return {height: input.shape[0], width: input.shape[1]};
+  } else {
+    return {height: input.height, width: input.width};
+  }
+}
+
+/**
+ * Normalizes the provided angle to the range -pi to pi.
+ * @param angle The angle in radians to be normalized.
+ */
+export function normalizeRadians(angle: number): number {
+  return angle - 2 * Math.PI * Math.floor((angle + Math.PI) / (2 * Math.PI));
+}
+
+/**
+ * Transform value ranges.
+ * @param fromMin Min of original value range.
+ * @param fromMax Max of original value range.
+ * @param toMin New min of transformed value range.
+ * @param toMax New max of transformed value range.
+ */
+export function transformValueRange(
+    fromMin: number, fromMax: number, toMin: number,
+    toMax: number): ValueTransform {
+  const fromRange = fromMax - fromMin;
+  const toRange = toMax - toMin;
+  const scale = toRange / fromRange;
+  const offset = toMin - fromMin * scale;
+  return {scale, offset};
+}
+
+/**
+ * Convert an image to an image tensor representation.
+ *
+ * The image tensor has a shape [1, height, width, colorChannel].
+ *
+ * @param input An image, video frame, or image tensor.
+ */
+export function toImageTensor(input: tf.Tensor3D|ImageData|HTMLVideoElement|
+                              HTMLImageElement|HTMLCanvasElement) {
+  return input instanceof tf.Tensor ? input : tf.browser.fromPixels(input);
+}
+
+/**
+ * Padding ratio of left, top, right, bottom, based on the output dimensions.
+ *
+ * The padding values are non-zero only when the "keep_aspect_ratio" is true.
+ *
+ * For instance, when the input image is 10x10 (width x height) and the
+ * output dimensions is 20x40 and "keep_aspect_ratio" is true, we should scale
+ * the input image to 20x20 and places it in the middle of the output image with
+ * an equal padding of 10 pixels at the top and the bottom. The result is
+ * therefore {left: 0, top: 0.25, right: 0, bottom: 0.25} (10/40 = 0.25f).
+ * @param roi The original rectangle to pad.
+ * @param targetSize The target width and height of the result rectangle.
+ * @param keepAspectRatio Whether keep aspect ratio. Default to false.
+ */
+export function padRoi(
+    roi: Rect, targetSize: InputResolution, keepAspectRatio = false): Padding {
+  if (!keepAspectRatio) {
+    return {top: 0, left: 0, right: 0, bottom: 0};
+  }
+
+  const targetH = targetSize.height;
+  const targetW = targetSize.width;
+
+  const tensorAspectRatio = targetH / targetW;
+  const roiAspectRatio = roi.h / roi.w;
+  let newWidth;
+  let newHeight;
+  let horizontalPadding = 0;
+  let verticalPadding = 0;
+  if (tensorAspectRatio > roiAspectRatio) {
+    // pad height;
+    newWidth = roi.w;
+    newHeight = roi.w * tensorAspectRatio;
+    verticalPadding = (1 - roiAspectRatio / tensorAspectRatio) / 2;
+  } else {
+    // pad width.
+    newWidth = roi.h / tensorAspectRatio;
+    newHeight = roi.h;
+    horizontalPadding = (1 - tensorAspectRatio / roiAspectRatio) / 2;
+  }
+
+  roi.w = newWidth;
+  roi.h = newHeight;
+
+  return {
+    top: verticalPadding,
+    left: horizontalPadding,
+    right: horizontalPadding,
+    bottom: verticalPadding
+  };
+}
+
+/**
+ * Get the rectangle information of an image, including xCenter, yCenter, width,
+ * height and rotation.
+ *
+ * @param imageSize imageSize is used to calculate the rectangle.
+ * @param normRect Optional. If normRect is not null, it will be used to get
+ *     a subarea rectangle information in the image. `imageSize` is used to
+ *     calculate the actual non-normalized coordinates.
+ */
+export function getRoi(imageSize: ImageSize, normRect?: Rect): Rect {
+  if (normRect) {
+    return {
+      xCenter: normRect.xCenter * imageSize.width,
+      yCenter: normRect.yCenter * imageSize.height,
+      w: normRect.w * imageSize.width,
+      h: normRect.h * imageSize.height,
+      rotation: normRect.rotation
+    };
+  } else {
+    return {
+      xCenter: 0.5 * imageSize.width,
+      yCenter: 0.5 * imageSize.height,
+      w: imageSize.width,
+      h: imageSize.height,
+      rotation: 0
+    };
+  }
+}
+
+/**
+ * Generate the projective transformation matrix to be used for `tf.transform`.
+ *
+ * See more documentation in `tf.transform`.
+ *
+ * @param subRect The rectangle to generate the projective transformation matrix
+ *     for.
+ * @param imageSize The original image height and width.
+ * @param flipHorizontally Whether flip the image horizontally.
+ * @param inputResolution The target height and width.
+ */
+export function getProjectiveTransformMatrix(
+    subRect: Rect, imageSize: ImageSize, flipHorizontally: boolean,
+    inputResolution: InputResolution):
+    [number, number, number, number, number, number, number, number] {
+  // The resulting matrix is multiplication of below matrices:
+  // M = postScaleMatrix * translateMatrix * rotateMatrix * flipMatrix *
+  //     scaleMatrix * initialTranslateMatrix
+  //
+  // For any point in the transformed image p, we can use the above matrix to
+  // calculate the projected point in the original image p'. So that:
+  // p' = p * M;
+  // Note: The transform matrix below assumes image coordinates is normalized
+  // to [0, 1] range.
+
+  // postScaleMatrix: Matrix to scale x, y to [0, 1] range
+  //   | g  0  0 |
+  //   | 0  h  0 |
+  //   | 0  0  1 |
+  const g = 1 / imageSize.width;
+  const h = 1 / imageSize.height;
+
+  // translateMatrix: Matrix to move the center to the subRect center.
+  //   | 1  0  e |
+  //   | 0  1  f |
+  //   | 0  0  1 |
+  const e = subRect.xCenter;
+  const f = subRect.yCenter;
+
+  // rotateMatrix: Matrix to do rotate the image around the subRect center.
+  //   | c -d  0 |
+  //   | d  c  0 |
+  //   | 0  0  1 |
+  const c = Math.cos(subRect.rotation);
+  const d = Math.sin(subRect.rotation);
+
+  // flipMatrix: Matrix for optional horizontal flip around the subRect center.
+  //   | fl 0  0 |
+  //   | 0  1  0 |
+  //   | 0  0  1 |
+  const flip = flipHorizontally ? -1 : 1;
+
+  // scaleMatrix: Matrix to scale x, y to subRect size.
+  //   | a  0  0 |
+  //   | 0  b  0 |
+  //   | 0  0  1 |
+  const a = subRect.w;
+  const b = subRect.h;
+
+  // initialTranslateMatrix: Matrix convert x, y to [-0.5, 0.5] range.
+  //   | 1  0 -0.5 |
+  //   | 0  1 -0.5 |
+  //   | 0  0  1   |
+
+  // M is a 3 by 3 matrix denoted by:
+  // | a0  a1  a2 |
+  // | b0  b1  b2 |
+  // | 0   0   1  |
+  // To use M with regular x, y coordinates, we need to normalize them first.
+  // Because x' = a0 * x + a1 * y + a2, y' = b0 * x + b1 * y + b2,
+  // we need to use factor (1/inputResolution.width) to normalize x for a0 and
+  // b0, similarly we need to use factor (1/inputResolution.height) to normalize
+  // y for a1 and b1.
+  // Also at the end, we need to de-normalize x' and y' to regular coordinates.
+  // So we need to use factor imageSize.width for a0, a1 and a2, similarly
+  // we need to use factor imageSize.height for b0, b1 and b2.
+  const a0 = (1 / inputResolution.width) * a * c * flip * g * imageSize.width;
+  const a1 = (1 / inputResolution.height) * -b * d * g * imageSize.width;
+  const a2 = (-0.5 * a * c * flip + 0.5 * b * d + e) * g * imageSize.width;
+  const b0 = (1 / inputResolution.width) * a * d * flip * h * imageSize.height;
+  const b1 = (1 / inputResolution.height) * b * c * h * imageSize.height;
+  const b2 = (-0.5 * b * c - 0.5 * a * d * flip + f) * h * imageSize.height;
+
+  return [a0, a1, a2, b0, b1, b2, 0, 0];
+}

--- a/pose-detection/src/calculators/interfaces/common_interfaces.ts
+++ b/pose-detection/src/calculators/interfaces/common_interfaces.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+export interface ImageSize {
+  height: number;
+  width: number;
+}
+
+export interface Padding {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+export type ValueTransform = {
+  scale: number,
+  offset: number
+};

--- a/pose-detection/src/calculators/interfaces/config_interfaces.ts
+++ b/pose-detection/src/calculators/interfaces/config_interfaces.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {InputResolution} from '../../types';
+
+export interface ImageToTensorConfig {
+  inputResolution: InputResolution;
+  keepAspectRatio?: boolean;
+}

--- a/pose-detection/src/calculators/interfaces/shape_interfaces.ts
+++ b/pose-detection/src/calculators/interfaces/shape_interfaces.ts
@@ -22,7 +22,7 @@
 export interface Rect {
   xCenter: number;
   yCenter: number;
-  h: number;
-  w: number;
+  height: number;
+  width: number;
   rotation?: number;
 }

--- a/pose-detection/src/calculators/interfaces/shape_interfaces.ts
+++ b/pose-detection/src/calculators/interfaces/shape_interfaces.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+/**
+ * A rectangle that contains center point, height, width and rotation info.
+ * Can be normalized or non-normalized.
+ */
+export interface Rect {
+  xCenter: number;
+  yCenter: number;
+  h: number;
+  w: number;
+  rotation?: number;
+}

--- a/pose-detection/src/calculators/shift_image_value.ts
+++ b/pose-detection/src/calculators/shift_image_value.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import * as tf from '@tensorflow/tfjs-core';
+import {transformValueRange} from './image_utils';
+
+export function shiftImageValue(
+    image: tf.Tensor4D, outputFloatRange: [number, number]): tf.Tensor4D {
+  // Calculate the scale and offset to shift from [0, 255] to [-1, 1].
+  const valueRange = transformValueRange(
+      0, 255, outputFloatRange[0] /* min */, outputFloatRange[1] /* max */);
+
+  // Shift value range.
+  return tf.tidy(
+      () => tf.add(tf.mul(image, valueRange.scale), valueRange.offset));
+}

--- a/pose-detection/src/constants.ts
+++ b/pose-detection/src/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+export const COCO_KEYPOINTS_NUM = 17;
+
+export const COCO_KEYPOINTS_NAMES = [
+  'nose', 'leftEye', 'rightEye', 'leftEar', 'rightEar', 'leftShoulder',
+  'rightShoulder', 'leftElbow', 'rightElbow', 'leftWrist', 'rightWrist',
+  'leftHip', 'rightHip', 'leftKnee', 'rightKnee', 'leftAnkle', 'rightAnkle'
+];

--- a/pose-detection/src/constants.ts
+++ b/pose-detection/src/constants.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-export const COCO_KEYPOINTS_NUM = 17;
-
-export const COCO_KEYPOINTS_NAMES = [
+export const COCO_KEYPOINTS = [
   'nose', 'leftEye', 'rightEye', 'leftEar', 'rightEar', 'leftShoulder',
   'rightShoulder', 'leftElbow', 'rightElbow', 'leftWrist', 'rightWrist',
   'leftHip', 'rightHip', 'leftKnee', 'rightKnee', 'leftAnkle', 'rightAnkle'

--- a/pose-detection/src/create_detector.ts
+++ b/pose-detection/src/create_detector.ts
@@ -32,6 +32,6 @@ export async function createDetector(
     case SupportedModels.PoseNet:
       return PosenetDetector.load(modelConfig);
     default:
-      throw new Error(`${model} is not a valid package name.`);
+      throw new Error(`${model} is not a supported model name.`);
   }
 }

--- a/pose-detection/src/create_detector.ts
+++ b/pose-detection/src/create_detector.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {PoseDetector} from './pose_detector';
+import {PosenetDetector} from './posenet/detector';
+import {PosenetModelConfig} from './posenet/types';
+import {SupportedModels} from './types';
+
+/**
+ * Create a pose detector instance.
+ *
+ * @param model The name of the pipeline to load.
+ */
+export async function createDetector(
+    model: SupportedModels,
+    modelConfig: PosenetModelConfig): Promise<PoseDetector> {
+  switch (model) {
+    case SupportedModels.PoseNet:
+      return PosenetDetector.load(modelConfig);
+    default:
+      throw new Error(`${model} is not a valid package name.`);
+  }
+}

--- a/pose-detection/src/index.ts
+++ b/pose-detection/src/index.ts
@@ -15,25 +15,9 @@
  * =============================================================================
  */
 
-import {PoseDetector} from './pose_detector';
-import {PosenetDetector} from './posenet/detector';
-import {ModelConfig, SupportedModels} from './types';
-
-/** Supported models. */
-export {SupportedModels};
-
-/**
- * Create a pose detector instance.
- *
- * @param model The name of the pipeline to load.
- */
-export async function createDetector(
-    model: SupportedModels,
-    modelConfig: ModelConfig = {}): Promise<PoseDetector> {
-  switch (model) {
-    case SupportedModels.posenet:
-      return PosenetDetector.load(modelConfig);
-    default:
-      throw new Error(`${model} is not a valid package name.`);
-  }
-}
+// Entry point to create a new detector instance.
+export {createDetector} from './create_detector';
+// PoseDetector class.
+export {PoseDetector} from './pose_detector';
+// Supported models enum.
+export {SupportedModels} from './types';

--- a/pose-detection/src/index.ts
+++ b/pose-detection/src/index.ts
@@ -32,7 +32,7 @@ export async function createDetector(
     modelConfig: ModelConfig = {}): Promise<PoseDetector> {
   switch (model) {
     case SupportedModels.posenet:
-      return await PosenetDetector.load(modelConfig);
+      return PosenetDetector.load(modelConfig);
     default:
       throw new Error(`${model} is not a valid package name.`);
   }

--- a/pose-detection/src/pose_detector.ts
+++ b/pose-detection/src/pose_detector.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {EstimationConfig, Keypoint, ModelConfig, PoseDetectorInput} from './types';
+import {EstimationConfig, ModelConfig, Pose, PoseDetectorInput} from './types';
 
 /**
  * User-facing interface for all pose detectors.
@@ -27,7 +27,7 @@ export interface PoseDetector {
    * @returns An array of poses, each pose contains an array of `Keypoint`s.
    */
   estimatePoses(image: PoseDetectorInput, config?: EstimationConfig):
-      Promise<[Keypoint[]]>;
+      Promise<Pose[]>;
 }
 
 /**
@@ -43,7 +43,8 @@ export abstract class BasePoseDetector implements PoseDetector {
   static async load(modelConfig: ModelConfig = {}): Promise<PoseDetector> {
     const detector = this.constructor();
     return detector;
-  };
+  }
 
-  abstract async estimatePoses(): Promise<[Keypoint[]]>;
+  abstract async estimatePoses(
+      image: PoseDetectorInput, config?: EstimationConfig): Promise<Pose[]>;
 }

--- a/pose-detection/src/posenet/calculators/decode_single_pose.ts
+++ b/pose-detection/src/posenet/calculators/decode_single_pose.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import {COCO_KEYPOINTS_NAMES} from '../../constants';
+import {Keypoint, Pose} from '../../types';
+import {PoseNetOutputStride} from '../types';
+import {argmax2d, getOffsetPoints, getPointsConfidence} from './decode_single_pose_util';
+
+/**
+ * Detects a single pose and finds its parts from part scores and offset
+ * vectors. It returns a single pose detection. It works as follows:
+ * argmax2d is done on the scores to get the y and x index in the heatmap
+ * with the highest score for each part, which is essentially where the
+ * part is most likely to exist. This produces a tensor of size 17x2, with
+ * each row being the y and x index in the heatmap for each keypoint.
+ * The offset vector for each part is retrieved by getting the
+ * y and x from the offsets corresponding to the y and x index in the
+ * heatmap for that part. This produces a tensor of size 17x2, with each
+ * row being the offset vector for the corresponding keypoint.
+ * To get the keypoint, each part’s heatmap y and x are multiplied
+ * by the output stride then added to their corresponding offset vector,
+ * which is in the same scale as the original image.
+ *
+ * @param heatmapScores 3-D tensor with shape `[height, width, numParts]`.
+ * The value of heatmapScores[y, x, k]` is the score of placing the `k`-th
+ * object part at position `(y, x)`.
+ *
+ * @param offsets 3-D tensor with shape `[height, width, numParts * 2]`.
+ * The value of [offsets[y, x, k], offsets[y, x, k + numParts]]` is the
+ * short range offset vector of the `k`-th  object part at heatmap
+ * position `(y, x)`.
+ *
+ * @param outputStride The output stride that was used when feed-forwarding
+ * through the PoseNet model.  Must be 32, 16, or 8.
+ *
+ * @return A promise that resolves with single pose with a confidence score,
+ * which contains an array of keypoints indexed by part id, each with a score
+ * and position.
+ */
+export async function decodeSinglePose(
+    heatmapScores: tf.Tensor3D, offsets: tf.Tensor3D,
+    outputStride: PoseNetOutputStride): Promise<Pose> {
+  let totalScore = 0.0;
+
+  const heatmapValues = argmax2d(heatmapScores);
+
+  const allTensorBuffers = await Promise.all(
+      [heatmapScores.buffer(), offsets.buffer(), heatmapValues.buffer()]);
+
+  const scoresBuffer = allTensorBuffers[0];
+  const offsetsBuffer = allTensorBuffers[1];
+  const heatmapValuesBuffer = allTensorBuffers[2];
+
+  const offsetPoints =
+      getOffsetPoints(heatmapValuesBuffer, outputStride, offsetsBuffer);
+  const offsetPointsBuffer = await offsetPoints.buffer();
+
+  const keypointConfidence =
+      Array.from(getPointsConfidence(scoresBuffer, heatmapValuesBuffer));
+
+  const keypoints = keypointConfidence.map((score, keypointId): Keypoint => {
+    totalScore += score;
+    return {
+      y: offsetPointsBuffer.get(keypointId, 0),
+      x: offsetPointsBuffer.get(keypointId, 1),
+      score,
+      name: COCO_KEYPOINTS_NAMES[keypointId]
+    };
+  });
+
+  heatmapValues.dispose();
+  offsetPoints.dispose();
+
+  return {keypoints, score: totalScore / keypoints.length};
+}

--- a/pose-detection/src/posenet/calculators/decode_single_pose.ts
+++ b/pose-detection/src/posenet/calculators/decode_single_pose.ts
@@ -16,7 +16,7 @@
  */
 
 import * as tf from '@tensorflow/tfjs-core';
-import {COCO_KEYPOINTS_NAMES} from '../../constants';
+import {COCO_KEYPOINTS} from '../../constants';
 import {Keypoint, Pose} from '../../types';
 import {PoseNetOutputStride} from '../types';
 import {argmax2d, getOffsetPoints, getPointsConfidence} from './decode_single_pose_util';
@@ -79,7 +79,7 @@ export async function decodeSinglePose(
       y: offsetPointsBuffer.get(keypointId, 0),
       x: offsetPointsBuffer.get(keypointId, 1),
       score,
-      name: COCO_KEYPOINTS_NAMES[keypointId]
+      name: COCO_KEYPOINTS[keypointId]
     };
   });
 

--- a/pose-detection/src/posenet/calculators/decode_single_pose_util.ts
+++ b/pose-detection/src/posenet/calculators/decode_single_pose_util.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import {COCO_KEYPOINTS_NUM} from '../../constants';
+import {Vector2D} from '../types';
+
+function mod(a: tf.Tensor1D, b: number): tf.Tensor1D {
+  return tf.tidy(() => {
+    const floored = tf.div(a, tf.scalar(b, 'int32'));
+
+    return tf.sub(a, tf.mul(floored, tf.scalar(b, 'int32')));
+  });
+}
+
+export function argmax2d(inputs: tf.Tensor3D): tf.Tensor2D {
+  const [height, width, depth] = inputs.shape;
+
+  return tf.tidy(() => {
+    const reshaped = tf.reshape(inputs, [height * width, depth]);
+    const coords = tf.argMax(reshaped, 0);
+
+    const yCoords = tf.expandDims(tf.div(coords, tf.scalar(width, 'int32')), 1);
+    const xCoords = tf.expandDims(mod(coords as tf.Tensor1D, width), 1);
+
+    return tf.concat([yCoords, xCoords], 1);
+  }) as tf.Tensor2D;
+}
+
+export function getPointsConfidence(
+    heatmapScores: tf.TensorBuffer<tf.Rank.R3>,
+    heatMapCoords: tf.TensorBuffer<tf.Rank.R2>): Float32Array {
+  const numKeypoints = heatMapCoords.shape[0];
+  const result = new Float32Array(numKeypoints);
+
+  for (let keypoint = 0; keypoint < numKeypoints; keypoint++) {
+    const y = heatMapCoords.get(keypoint, 0);
+    const x = heatMapCoords.get(keypoint, 1);
+    result[keypoint] = heatmapScores.get(y, x, keypoint);
+  }
+
+  return result;
+}
+
+export function getOffsetPoints(
+    heatMapCoordsBuffer: tf.TensorBuffer<tf.Rank.R2>, outputStride: number,
+    offsetsBuffer: tf.TensorBuffer<tf.Rank.R3>): tf.Tensor2D {
+  return tf.tidy(() => {
+    const offsetVectors = getOffsetVectors(heatMapCoordsBuffer, offsetsBuffer);
+
+    return tf.add(
+        tf.cast(
+            tf.mul(
+                heatMapCoordsBuffer.toTensor(),
+                tf.scalar(outputStride, 'int32')),
+            'float32'),
+        offsetVectors);
+  });
+}
+
+export function getOffsetVectors(
+    heatMapCoordsBuffer: tf.TensorBuffer<tf.Rank.R2>,
+    offsetsBuffer: tf.TensorBuffer<tf.Rank.R3>): tf.Tensor2D {
+  const result: number[] = [];
+
+  for (let keypoint = 0; keypoint < COCO_KEYPOINTS_NUM; keypoint++) {
+    const heatmapY = heatMapCoordsBuffer.get(keypoint, 0).valueOf();
+    const heatmapX = heatMapCoordsBuffer.get(keypoint, 1).valueOf();
+
+    const {x, y} = getOffsetPoint(heatmapY, heatmapX, keypoint, offsetsBuffer);
+
+    result.push(y);
+    result.push(x);
+  }
+
+  return tf.tensor2d(result, [COCO_KEYPOINTS_NUM, 2]);
+}
+
+function getOffsetPoint(
+    y: number, x: number, keypoint: number,
+    offsetsBuffer: tf.TensorBuffer<tf.Rank.R3>): Vector2D {
+  return {
+    y: offsetsBuffer.get(y, x, keypoint),
+    x: offsetsBuffer.get(y, x, keypoint + COCO_KEYPOINTS_NUM)
+  };
+}

--- a/pose-detection/src/posenet/calculators/decode_single_pose_util.ts
+++ b/pose-detection/src/posenet/calculators/decode_single_pose_util.ts
@@ -16,7 +16,7 @@
  */
 
 import * as tf from '@tensorflow/tfjs-core';
-import {COCO_KEYPOINTS_NUM} from '../../constants';
+import {COCO_KEYPOINTS} from '../../constants';
 import {Vector2D} from '../types';
 
 function mod(a: tf.Tensor1D, b: number): tf.Tensor1D {
@@ -77,7 +77,7 @@ export function getOffsetVectors(
     offsetsBuffer: tf.TensorBuffer<tf.Rank.R3>): tf.Tensor2D {
   const result: number[] = [];
 
-  for (let keypoint = 0; keypoint < COCO_KEYPOINTS_NUM; keypoint++) {
+  for (let keypoint = 0; keypoint < COCO_KEYPOINTS.length; keypoint++) {
     const heatmapY = heatMapCoordsBuffer.get(keypoint, 0).valueOf();
     const heatmapX = heatMapCoordsBuffer.get(keypoint, 1).valueOf();
 
@@ -87,7 +87,7 @@ export function getOffsetVectors(
     result.push(x);
   }
 
-  return tf.tensor2d(result, [COCO_KEYPOINTS_NUM, 2]);
+  return tf.tensor2d(result, [COCO_KEYPOINTS.length, 2]);
 }
 
 function getOffsetPoint(
@@ -95,6 +95,6 @@ function getOffsetPoint(
     offsetsBuffer: tf.TensorBuffer<tf.Rank.R3>): Vector2D {
   return {
     y: offsetsBuffer.get(y, x, keypoint),
-    x: offsetsBuffer.get(y, x, keypoint + COCO_KEYPOINTS_NUM)
+    x: offsetsBuffer.get(y, x, keypoint + COCO_KEYPOINTS.length)
   };
 }

--- a/pose-detection/src/posenet/calculators/flip_poses.ts
+++ b/pose-detection/src/posenet/calculators/flip_poses.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ImageSize} from '../../calculators/interfaces/common_interfaces';
+import {Pose} from '../../types';
+
+export function flipPosesHorizontal(
+    poses: Pose[], imageSize: ImageSize): Pose[] {
+  poses.forEach(pose => pose.keypoints.forEach(kp => {
+    kp.x = imageSize.width - 1 - kp.x;
+  }));
+
+  return poses;
+}

--- a/pose-detection/src/posenet/calculators/scale_poses.ts
+++ b/pose-detection/src/posenet/calculators/scale_poses.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ImageSize, Padding} from '../../calculators/interfaces/common_interfaces';
+import {InputResolution, Pose} from '../../types';
+
+export function scalePoses(
+    poses: Pose[], imageSize: ImageSize, inputResolution: InputResolution,
+    padding: Padding): Pose[] {
+  const {height, width} = imageSize;
+  const scaleY =
+      height / (inputResolution.height * (1 - padding.top - padding.bottom));
+  const scaleX =
+      width / (inputResolution.width * (1 - padding.left - padding.right));
+
+  const offsetY = -padding.top;
+  const offsetX = -padding.left;
+
+  if (scaleX === 1 && scaleY === 1 && offsetY === 0 && offsetX === 0) {
+    return poses;
+  }
+
+  poses.forEach(pose => pose.keypoints.forEach(kp => {
+    kp.x = kp.x * scaleX + offsetX;
+    kp.y = kp.y * scaleY + offsetY;
+  }));
+
+  return poses;
+}

--- a/pose-detection/src/posenet/constants.ts
+++ b/pose-detection/src/posenet/constants.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {PoseNetEstimationConfig, PosenetModelConfig, PoseNetOutputStride} from './types';
+
+// The default configuration for loading MobileNetV1 based PoseNet.
+//
+// (And for references, the default configuration for loading ResNet
+// based PoseNet is also included).
+//
+// ```
+// const RESNET_CONFIG = {
+//   architecture: 'ResNet50',
+//   outputStride: 32,
+//   quantBytes: 2,
+// } as ModelConfig;
+// ```
+export const MOBILENET_V1_CONFIG: PosenetModelConfig = {
+  architecture: 'MobileNetV1',
+  outputStride: 16,
+  multiplier: 0.75,
+  inputResolution: {height: 257, width: 257}
+};
+
+export const VALID_ARCHITECTURE = ['MobileNetV1', 'ResNet50'];
+export const VALID_STRIDE = {
+  'MobileNetV1': [8, 16],
+  'ResNet50': [16]
+};
+export const VALID_OUTPUT_STRIDES: PoseNetOutputStride[] = [8, 16, 32];
+export const VALID_MULTIPLIER = {
+  'MobileNetV1': [0.50, 0.75, 1.0],
+  'ResNet50': [1.0]
+};
+export const VALID_QUANT_BYTES = [1, 2, 4];
+
+export const SINGLE_PERSON_ESTIMATION_CONFIG: PoseNetEstimationConfig = {
+  maxPoses: 1,
+  flipHorizontal: false
+};
+
+export const MULTI_PERSON_ESTIMATION_CONFIG: PoseNetEstimationConfig = {
+  maxPoses: 5,
+  flipHorizontal: false,
+  scoreThreshold: 0.5,
+  nmsRadius: 20
+};
+
+export const RESNET_MEAN = [-123.15, -115.90, -103.06];

--- a/pose-detection/src/posenet/detector.ts
+++ b/pose-detection/src/posenet/detector.ts
@@ -15,24 +15,168 @@
  * =============================================================================
  */
 
-import {BasePoseDetector, PoseDetector} from '../pose_detector';
-import {Keypoint, ModelConfig} from '../types';
+import * as tfconv from '@tensorflow/tfjs-converter';
+import * as tf from '@tensorflow/tfjs-core';
+import {convertImageToTensor} from '../calculators/convert_image_to_tensor';
+import {getImageSize} from '../calculators/image_utils';
+import {shiftImageValue} from '../calculators/shift_image_value';
 
+import {BasePoseDetector, PoseDetector} from '../pose_detector';
+import {InputResolution, Pose, PoseDetectorInput} from '../types';
+import {decodeSinglePose} from './calculators/decode_single_pose';
+import {flipPosesHorizontal} from './calculators/flip_poses';
+import {scalePoses} from './calculators/scale_poses';
+
+import {MOBILENET_V1_CONFIG, RESNET_MEAN} from './constants';
+import {assertValidOutputStride, assertValidResolution, validateEstimationConfig, validateModelConfig} from './detector_utils';
+import {getValidInputResolutionDimensions, mobileNetCheckpoint, resNet50Checkpoint} from './load_utils';
+import {PoseNetArchitecture, PoseNetEstimationConfig, PosenetModelConfig, PoseNetOutputStride} from './types';
+
+/**
+ * PoseNet detector class.
+ */
 export class PosenetDetector extends BasePoseDetector {
+  private inputResolution: InputResolution;
+  private architecture: PoseNetArchitecture;
+  private outputStride: PoseNetOutputStride;
+  private maxPoses: number;
+
   // Should not be called outside.
-  private constructor() {
+  private constructor(
+      private readonly posenetModel: tfconv.GraphModel,
+      config: PosenetModelConfig) {
     super();
-    // initialize global states.
+
+    // validate params.
+    const inputShape =
+        this.posenetModel.inputs[0].shape as [number, number, number, number];
+    tf.util.assert(
+        (inputShape[1] === -1) && (inputShape[2] === -1),
+        () => `Input shape [${inputShape[1]}, ${inputShape[2]}] ` +
+            `must both be equal to or -1`);
+
+    const validInputResolution = getValidInputResolutionDimensions(
+        config.inputResolution, config.outputStride);
+
+    assertValidOutputStride(config.outputStride);
+    assertValidResolution(validInputResolution, config.outputStride);
+
+    this.inputResolution = validInputResolution;
+    this.outputStride = config.outputStride;
+    this.architecture = config.architecture;
   }
 
-  // Use this method to instantiate new instance and async load.
-  static async load(modelConfig: ModelConfig = {}): Promise<PoseDetector> {
-    const detector = this.constructor();
-    // async load with modelConfig.
-    return detector;
-  };
+  /**
+   * Loads the PoseNet model instance from a checkpoint, with the ResNet
+   * or MobileNet architecture. The model to be loaded is configurable using the
+   * config dictionary ModelConfig. Please find more details in the
+   * documentation of the ModelConfig.
+   *
+   * @param config ModelConfig dictionary that contains parameters for
+   * the PoseNet loading process. Please find more details of each parameters
+   * in the documentation of the ModelConfig interface. The predefined
+   * `MOBILENET_V1_CONFIG` and `RESNET_CONFIG` can also be used as references
+   * for defining your customized config.
+   */
+  static async load(modelConfig: PosenetModelConfig = MOBILENET_V1_CONFIG):
+      Promise<PoseDetector> {
+    const config = validateModelConfig(modelConfig);
+    if (config.architecture === 'ResNet50') {
+      // Load ResNet50 model.
+      const defaultUrl =
+          resNet50Checkpoint(config.outputStride, config.quantBytes);
+      const model = await tfconv.loadGraphModel(config.modelUrl || defaultUrl);
 
-  async estimatePoses(): Promise<[Keypoint[]]> {
-    return [null];
+      return this.constructor(model, config);
+    }
+
+    // Load MobileNetV1 model.
+    const defaultUrl = mobileNetCheckpoint(
+        config.outputStride, config.multiplier, config.quantBytes);
+    const model = await tfconv.loadGraphModel(config.modelUrl || defaultUrl);
+
+    return new PosenetDetector(model, config);
+  }
+
+  /**
+   * Estimates poses for an image or video frame.
+   *
+   * This does standard ImageNet pre-processing before inferring through the
+   * model. The image should pixels should have values [0-255]. It returns a
+   * single pose or multiple poses based on the maxPose parameter from the
+   * `config`.
+   *
+   * @param input
+   * ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement) The input
+   * image to feed through the network.
+   *
+   * @param config SinglePersonEstimationConfig object that contains
+   * parameters for the PoseNet inference using single pose estimation.
+   *
+   * @return An pose and its scores, containing keypoints and
+   * the corresponding keypoint scores.  The positions of the keypoints are
+   * in the same scale as the original image
+   */
+  async estimatePoses(
+      image: PoseDetectorInput,
+      estimationConfig: PoseNetEstimationConfig): Promise<Pose[]> {
+    const config = validateEstimationConfig(estimationConfig);
+
+    if (image == null) {
+      return [];
+    }
+
+    this.maxPoses = config.maxPoses;
+
+    if (this.maxPoses > 1) {
+      throw new Error('Multi-person poses is not implemented yet.');
+    }
+
+    // ==== ConvertImageToTensor =============================================
+    const {imageTensor, padding} = convertImageToTensor(
+        image, {inputResolution: this.inputResolution, keepAspectRatio: true});
+
+    // ==== ShiftImageTensorValue =============================================
+    const imageTransformed = this.architecture === 'ResNet50' ?
+        tf.add(imageTensor, RESNET_MEAN) :
+        shiftImageValue(imageTensor, [-1, 1]);
+
+    // ==== ModelInference ====================================================
+    const results =
+        this.posenetModel.predict(imageTransformed) as tf.Tensor4D[];
+
+    let offsets, heatmap;
+    if (this.architecture === 'ResNet50') {
+      offsets = tf.squeeze(results[2]) as tf.Tensor3D;
+      heatmap = tf.squeeze(results[3]) as tf.Tensor3D;
+    } else {
+      offsets = tf.squeeze(results[0]) as tf.Tensor3D;
+      heatmap = tf.squeeze(results[1]) as tf.Tensor3D;
+    }
+    const heatmapScores = tf.sigmoid(heatmap) as tf.Tensor3D;
+
+    // ==== DecodeResults =====================================================
+    const pose =
+        await decodeSinglePose(heatmapScores, offsets, this.outputStride);
+    const poses = [pose];
+
+    // ==== ScaleBackKeyPoints ================================================
+    const imageSize = getImageSize(image);
+    let scaledPoses =
+        scalePoses(poses, imageSize, this.inputResolution, padding);
+
+    // ==== FlipPoseIfNeeded ==================================================
+    if (config.flipHorizontal) {
+      scaledPoses = flipPosesHorizontal(scaledPoses, imageSize);
+    }
+
+    imageTensor.dispose();
+    imageTransformed.dispose();
+    tf.dispose(results);
+    offsets.dispose();
+    heatmap.dispose();
+    heatmapScores.dispose();
+
+    return scaledPoses;
   }
 }

--- a/pose-detection/src/posenet/detector_utils.ts
+++ b/pose-detection/src/posenet/detector_utils.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import {InputResolution} from '../types';
+
+import {MOBILENET_V1_CONFIG, MULTI_PERSON_ESTIMATION_CONFIG, SINGLE_PERSON_ESTIMATION_CONFIG, VALID_ARCHITECTURE, VALID_MULTIPLIER, VALID_OUTPUT_STRIDES, VALID_QUANT_BYTES, VALID_STRIDE} from './constants';
+import {PoseNetEstimationConfig, PosenetModelConfig, PoseNetOutputStride} from './types';
+
+export function validateModelConfig(modelConfig: PosenetModelConfig):
+    PosenetModelConfig {
+  const config = modelConfig || MOBILENET_V1_CONFIG;
+
+  if (config.architecture == null) {
+    config.architecture = 'MobileNetV1';
+  }
+
+  if (VALID_ARCHITECTURE.indexOf(config.architecture) < 0) {
+    throw new Error(
+        `Invalid architecture ${config.architecture}. ` +
+        `Should be one of ${VALID_ARCHITECTURE}`);
+  }
+
+  if (config.inputResolution == null) {
+    config.inputResolution = {height: 257, width: 257};
+  }
+
+  if (config.outputStride == null) {
+    config.outputStride = 16;
+  }
+
+  if (VALID_STRIDE[config.architecture].indexOf(config.outputStride) < 0) {
+    throw new Error(
+        `Invalid outputStride ${config.outputStride}. ` +
+        `Should be one of ${VALID_STRIDE[config.architecture]} ` +
+        `for architecture ${config.architecture}.`);
+  }
+
+  if (config.multiplier == null) {
+    config.multiplier = 1.0;
+  }
+
+  if (VALID_MULTIPLIER[config.architecture].indexOf(config.multiplier) < 0) {
+    throw new Error(
+        `Invalid multiplier ${config.multiplier}. ` +
+        `Should be one of ${VALID_MULTIPLIER[config.architecture]} ` +
+        `for architecture ${config.architecture}.`);
+  }
+
+  if (config.quantBytes == null) {
+    config.quantBytes = 4;
+  }
+
+  if (VALID_QUANT_BYTES.indexOf(config.quantBytes) < 0) {
+    throw new Error(
+        `Invalid quantBytes ${config.quantBytes}. ` +
+        `Should be one of ${VALID_QUANT_BYTES} ` +
+        `for architecture ${config.architecture}.`);
+  }
+
+  if (config.architecture === 'MobileNetV1' && config.outputStride === 32 &&
+      config.multiplier !== 1) {
+    throw new Error(
+        `When using an output stride of 32, ` +
+        `you must select 1 as the multiplier.`);
+  }
+
+  return config;
+}
+
+export function assertValidOutputStride(outputStride: PoseNetOutputStride) {
+  tf.util.assert(
+      VALID_OUTPUT_STRIDES.indexOf(outputStride) >= 0,
+      () => `outputStride of ${outputStride} is invalid. ` +
+          `It must be either 8 or 16.`);
+}
+
+function isValidInputResolution(
+    resolution: number, outputStride: number): boolean {
+  return (resolution - 1) % outputStride === 0;
+}
+
+export function assertValidResolution(
+    resolution: InputResolution, outputStride: number) {
+  tf.util.assert(
+      isValidInputResolution(resolution.height, outputStride),
+      () => `height of ${resolution.height} is invalid for output stride ` +
+          `${outputStride}.`);
+
+  tf.util.assert(
+      isValidInputResolution(resolution.width, outputStride),
+      () => `width of ${resolution.width} is invalid for output stride ` +
+          `${outputStride}.`);
+}
+
+export function validateEstimationConfig(
+    estimationConfig: PoseNetEstimationConfig): PoseNetEstimationConfig {
+  let config = estimationConfig || SINGLE_PERSON_ESTIMATION_CONFIG;
+
+  if (config.maxPoses <= 0) {
+    throw new Error(`Invalid maxPoses ${config.maxPoses}. Should be > 0.`);
+  }
+
+  if (config.maxPoses === 1) {
+    // Single pose estimation.
+    config = {...SINGLE_PERSON_ESTIMATION_CONFIG, ...config};
+  } else {
+    // Multi-poses estimation, needs additional check for multi-poses
+    // parameters.
+    config = {...MULTI_PERSON_ESTIMATION_CONFIG, ...config};
+
+    if (config.scoreThreshold < 0.0 || config.scoreThreshold > 1.0) {
+      throw new Error(
+          `Invalid scoreThreshold ${config.scoreThreshold}. ` +
+          `Should be in range [0.0, 1.0]`);
+    }
+
+    if (config.nmsRadius <= 0) {
+      throw new Error(`Invalid nmsRadius ${config.nmsRadius}.`);
+    }
+  }
+
+  return config;
+}

--- a/pose-detection/src/posenet/load_utils.ts
+++ b/pose-detection/src/posenet/load_utils.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {InputResolution} from '../types';
+import {PoseNetOutputStride} from './types';
+
+const MOBILENET_BASE_URL =
+    'https://storage.googleapis.com/tfjs-models/savedmodel/posenet/mobilenet/';
+const RESNET50_BASE_URL =
+    'https://storage.googleapis.com/tfjs-models/savedmodel/posenet/resnet50/';
+
+// The PoseNet 2.0 ResNet50 models use the latest TensorFlow.js 1.0 model
+// format.
+export function resNet50Checkpoint(stride: number, quantBytes: number): string {
+  const graphJson = `model-stride${stride}.json`;
+  // quantBytes=4 corresponding to the non-quantized full-precision checkpoints.
+  if (quantBytes === 4) {
+    return RESNET50_BASE_URL + `float/` + graphJson;
+  } else {
+    return RESNET50_BASE_URL + `quant${quantBytes}/` + graphJson;
+  }
+}
+
+// The PoseNet 2.0 MobileNetV1 models use the latest TensorFlow.js 1.0 model
+// format.
+export function mobileNetCheckpoint(
+    stride: number, multiplier: number, quantBytes: number): string {
+  const toStr: {[key: number]: string} = {1.0: '100', 0.75: '075', 0.50: '050'};
+  const graphJson = `model-stride${stride}.json`;
+  // quantBytes=4 corresponding to the non-quantized full-precision checkpoints.
+  if (quantBytes === 4) {
+    return MOBILENET_BASE_URL + `float/${toStr[multiplier]}/` + graphJson;
+  } else {
+    return MOBILENET_BASE_URL + `quant${quantBytes}/${toStr[multiplier]}/` +
+        graphJson;
+  }
+}
+
+export function getValidInputResolutionDimensions(
+    inputResolution: InputResolution,
+    outputStride: PoseNetOutputStride): InputResolution {
+  return {
+    height: toValidInputResolution(inputResolution.height, outputStride),
+    width: toValidInputResolution(inputResolution.width, outputStride)
+  };
+}
+
+export function toValidInputResolution(
+    inputResolution: number, outputStride: PoseNetOutputStride): number {
+  if (isValidInputResolution(inputResolution, outputStride)) {
+    return inputResolution;
+  }
+
+  return Math.floor(inputResolution / outputStride) * outputStride + 1;
+}
+
+function isValidInputResolution(
+    resolution: number, outputStride: number): boolean {
+  return (resolution - 1) % outputStride === 0;
+}

--- a/pose-detection/src/posenet/posenet_test.ts
+++ b/pose-detection/src/posenet/posenet_test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+// tslint:disable-next-line: no-imports-from-dist
+import {ALL_ENVS, describeWithFlags} from '@tensorflow/tfjs-core/dist/jasmine_util';
+
+import * as poseDetection from '../index';
+
+describeWithFlags('PoseNet', ALL_ENVS, () => {
+  let detector: poseDetection.PoseDetector;
+  beforeEach(async () => {
+    // Note: this makes a network request for model assets.
+    detector = await poseDetection.createDetector(
+        poseDetection.SupportedModels.PoseNet, {
+          quantBytes: 4,
+          architecture: 'MobileNetV1',
+          outputStride: 16,
+          inputResolution: {width: 514, height: 513},
+          multiplier: 1
+        });
+  });
+
+  it('estimatePoses does not leak memory', async () => {
+    const input: tf.Tensor3D = tf.zeros([128, 128, 3]);
+
+    const beforeTensors = tf.memory().numTensors;
+
+    await detector.estimatePoses(input, {maxPoses: 1, flipHorizontal: false});
+
+    expect(tf.memory().numTensors).toEqual(beforeTensors);
+  });
+});

--- a/pose-detection/src/posenet/types.ts
+++ b/pose-detection/src/posenet/types.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import {EstimationConfig, InputResolution, ModelConfig} from '../types';
+
+export type PoseNetOutputStride = 32|16|8;
+export type PoseNetArchitecture = 'ResNet50'|'MobileNetV1';
+export type PoseNetDecodingMethod = 'single-person'|'multi-person';
+export type MobileNetMultiplier = 0.50|0.75|1.0;
+
+/**
+ * Additional PoseNet model loading config.
+ *
+ * `architecture`: PoseNetArchitecture. It determines wich PoseNet architecture
+ * to load. The supported architectures are: MobileNetV1 and ResNet.
+ *
+ * `outputStride`: Specifies the output stride of the PoseNet model.
+ * The smaller the value, the larger the output resolution, and more accurate
+ * the model at the cost of speed.  Set this to a larger value to increase speed
+ * at the cost of accuracy. Stride 32 is supported for ResNet and
+ * stride 8,16,32 are supported for various MobileNetV1 models.
+ *
+ * * `inputResolution`: A number or an Object of type {width: number, height:
+ * number}. Specifies the size the input image is scaled to before feeding it
+ * through the PoseNet model.  The larger the value, more accurate the model at
+ * the cost of speed. Set this to a smaller value to increase speed at the cost
+ * of accuracy. If a number is provided, the input will be resized and padded to
+ * be a square with the same width and height.  If width and height are
+ * provided, the input will be resized and padded to the specified width and
+ * height.
+ *
+ * `multiplier`: Optional. Options: 1.01, 1.0, 0.75, or 0.50.
+ * The value is used only by MobileNet architecture. It is the float
+ * multiplier for the depth (number of channels) for all convolution ops.
+ * The larger the value, the larger the size of the layers, and more accurate
+ * the model at the cost of speed. Set this to a smaller value to increase speed
+ * at the cost of accuracy.
+ *
+ * `modelUrl`: Optional. An optional string that specifies custom url of the
+ * model. This is useful for area/countries that don't have access to the model
+ * hosted on GCP.
+ */
+export interface PosenetModelConfig extends ModelConfig {
+  architecture: PoseNetArchitecture;
+  outputStride: PoseNetOutputStride;
+  inputResolution: InputResolution;
+  multiplier?: MobileNetMultiplier;
+  modelUrl?: string;
+}
+
+/**
+ * Posenet Specific Inference Config
+ *
+ * `scoreThreshold`: For maxPoses > 1. Only return instance detections that have
+ * root part score greater or equal to this value. Defaults to 0.5
+ *
+ * `nmsRadius`: For maxPoses > 1. Non-maximum suppression part distance in
+ * pixels. It needs to be strictly positive. Two parts suppress each other if
+ * they are less than `nmsRadius` pixels away. Defaults to 20.
+ */
+export interface PoseNetEstimationConfig extends EstimationConfig {
+  scoreThreshold?: number;
+  nmsRadius?: number;
+}
+
+export type Vector2D = {
+  y: number,
+  x: number
+};

--- a/pose-detection/src/types.ts
+++ b/pose-detection/src/types.ts
@@ -17,14 +17,22 @@
 import * as tf from '@tensorflow/tfjs-core';
 
 export enum SupportedModels {
-  posenet = 'posenet'
+  PoseNet = 'posenet'
 }
+
+export type QuantBytes = 1|2|4;
 
 /**
  * Common config to create the pose detector.
+ *
+ * `quantBytes`: Optional. Options: 1, 2, or 4.  This parameter affects weight
+ * quantization in the models. The available options are
+ * 1 byte, 2 bytes, and 4 bytes. The higher the value, the larger the model size
+ * and thus the longer the loading time, the lower the value, the shorter the
+ * loading time but lower the accuracy.
  */
 export interface ModelConfig {
-  quantBytes?: number;
+  quantBytes?: QuantBytes;
 }
 
 /**
@@ -37,15 +45,26 @@ export type PoseDetectorInput =
  * Common config for the `estimatePoses` method.
  */
 export interface EstimationConfig {
-  maxPoses?: number;
+  maxPoses: number;
   flipHorizontal?: boolean;
-  smoothLandmarks?: boolean;
-  maxContinousChecks?: number;
+}
+
+export interface InputResolution {
+  width: number;
+  height: number;
 }
 
 /**
  * A keypoint that contains coordinate information.
  */
 export interface Keypoint {
-  x: number, y: number
+  x: number;
+  y: number;
+  score?: number;
+  name?: string;
+}
+
+export interface Pose {
+  keypoints: Keypoint[];
+  score?: number;
 }


### PR DESCRIPTION
This PR includes below changes:
1. Add PoseNet single pose estimation.
2. Add convertImageToTensor, to be shared by all image processing models.
2. Setup test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/611)
<!-- Reviewable:end -->
