### PR TITLE
[speech-command]Fix sampleRate mismatch.

### DIFF
--- a/speech-commands/src/browser_fft_extractor.ts
+++ b/speech-commands/src/browser_fft_extractor.ts
@@ -181,14 +181,9 @@ export class BrowserFftFeatureExtractor implements FeatureExtractor {
     }
 
     this.stream = await getAudioMediaStream(audioTrackConstraints);
+    this.audioContext = new this.audioContextConstructor(
+                            {sampleRate: this.sampleRateHz}) as AudioContext;
 
-    this.audioContext = new this.audioContextConstructor() as AudioContext;
-    if (this.audioContext.sampleRate !== this.sampleRateHz) {
-      console.warn(
-          `Mismatch in sampling rate: ` +
-          `Expected: ${this.sampleRateHz}; ` +
-          `Actual: ${this.audioContext.sampleRate}`);
-    }
     const streamSource = this.audioContext.createMediaStreamSource(this.stream);
     this.analyser = this.audioContext.createAnalyser();
     this.analyser.fftSize = this.fftSize * 2;


### PR DESCRIPTION
Fix error: Mismatch in sampling rate: Expected: 44100; Actual: 48000
Browser now allows setting sampling rate. Fixes https://github.com/tensorflow/tfjs/issues/3845

It is available in Firefox: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext
And chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=432248

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/612)
<!-- Reviewable:end -->
