### PR TITLE
[pose-detection]Allow timestamp as a user input.

### DIFF
--- a/pose-detection/src/blazepose/calculators/landmarks_smoothing.ts
+++ b/pose-detection/src/blazepose/calculators/landmarks_smoothing.ts
@@ -19,7 +19,7 @@ import {SECOND_TO_MICRO_SECONDS} from '../../calculators/constants';
 import {getImageSize} from '../../calculators/image_utils';
 import {landmarksToNormalizedLandmarks} from '../../calculators/landmarks_to_normalized_landmarks';
 import {normalizedLandmarksToLandmarks} from '../../calculators/normalized_landmarks_to_landmarks';
-import {Keypoint} from '../../types';
+import {Keypoint, PoseDetectorInput} from '../../types';
 import {LandmarksFilter} from './interfaces/common_interfaces';
 import {LandmarksSmoothingConfig} from './interfaces/config_interfaces';
 import {LandmarksOneEuroFilter} from './landmarks_one_euro_filter';
@@ -43,13 +43,14 @@ export class LandmarksSmoothingFilter {
     }
   }
 
-  apply(landmarks: Keypoint[], image: HTMLVideoElement): Keypoint[] {
+  apply(landmarks: Keypoint[], image: PoseDetectorInput, timestamp: number):
+      Keypoint[] {
     if (landmarks == null) {
       this.landmarksFilter.reset();
       return null;
     }
     const imageSize = getImageSize(image);
-    const microSeconds = image.currentTime * SECOND_TO_MICRO_SECONDS;
+    const microSeconds = timestamp * SECOND_TO_MICRO_SECONDS;
     const scaledLandmarks =
         normalizedLandmarksToLandmarks(landmarks, imageSize);
     const scaledOutLandmarks =

--- a/pose-detection/src/blazepose/calculators/landmarks_smoothing.ts
+++ b/pose-detection/src/blazepose/calculators/landmarks_smoothing.ts
@@ -50,7 +50,7 @@ export class LandmarksSmoothingFilter {
       return null;
     }
     const imageSize = getImageSize(image);
-    const microSeconds = timestamp * SECOND_TO_MICRO_SECONDS;
+    const microSeconds = timestamp;
     const scaledLandmarks =
         normalizedLandmarksToLandmarks(landmarks, imageSize);
     const scaledOutLandmarks =

--- a/pose-detection/src/blazepose/calculators/landmarks_smoothing.ts
+++ b/pose-detection/src/blazepose/calculators/landmarks_smoothing.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {SECOND_TO_MICRO_SECONDS} from '../../calculators/constants';
 import {getImageSize} from '../../calculators/image_utils';
 import {landmarksToNormalizedLandmarks} from '../../calculators/landmarks_to_normalized_landmarks';
 import {normalizedLandmarksToLandmarks} from '../../calculators/normalized_landmarks_to_landmarks';

--- a/pose-detection/src/blazepose/calculators/landmarks_smoothing.ts
+++ b/pose-detection/src/blazepose/calculators/landmarks_smoothing.ts
@@ -49,11 +49,10 @@ export class LandmarksSmoothingFilter {
       return null;
     }
     const imageSize = getImageSize(image);
-    const microSeconds = timestamp;
     const scaledLandmarks =
         normalizedLandmarksToLandmarks(landmarks, imageSize);
     const scaledOutLandmarks =
-        this.landmarksFilter.apply(scaledLandmarks, microSeconds);
+        this.landmarksFilter.apply(scaledLandmarks, timestamp);
 
     return landmarksToNormalizedLandmarks(scaledOutLandmarks, imageSize);
   }

--- a/pose-detection/src/blazepose/calculators/non_max_suppression.ts
+++ b/pose-detection/src/blazepose/calculators/non_max_suppression.ts
@@ -33,7 +33,7 @@ export async function nonMaxSuppression(
   const selectedIds = await selectedIdsTensor.array();
 
   const selectedDetections =
-      detections.filter((_, i) => selectedIds.includes(i));
+      detections.filter((_, i) => (selectedIds.indexOf(i) > -1));
 
   tf.dispose([detectionsTensor, scoresTensor, selectedIdsTensor]);
 

--- a/pose-detection/src/blazepose/detector.ts
+++ b/pose-detection/src/blazepose/detector.ts
@@ -17,6 +17,7 @@
 
 import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
+import {SECOND_TO_MICRO_SECONDS} from '../calculators/constants';
 import {convertImageToTensor} from '../calculators/convert_image_to_tensor';
 import {getImageSize, toImageTensor} from '../calculators/image_utils';
 import {ImageSize} from '../calculators/interfaces/common_interfaces';
@@ -60,7 +61,7 @@ export class BlazeposeDetector extends BasePoseDetector {
   private readonly anchorTensor: AnchorTensor;
 
   private maxPoses: number;
-  private timestamp: number;
+  private timestamp: number;  // In microseconds.
 
   // Store global states.
   private regionOfInterest: Rect = null;
@@ -129,9 +130,9 @@ export class BlazeposeDetector extends BasePoseDetector {
    *       enableSmoothing: Optional. Default to true. Smooth pose landmarks
    *       coordinates and visibility scores to reduce jitter.
    *
-   * @param timestamp Optional. In seconds. This is useful when image is a
-   *     tensor, which doesn't have timestamp info. Or to override timestamp in
-   *     a video.
+   * @param timestamp Optional. In microseconds, i.e. 1e-6 of a second. This is
+   *     useful when image is a tensor, which doesn't have timestamp info. Or
+   *     to override timestamp in a video.
    *
    * @return An array of `Pose`s.
    */
@@ -155,7 +156,8 @@ export class BlazeposeDetector extends BasePoseDetector {
       this.timestamp = timestamp;
     } else {
       // For static images, timestamp should be null.
-      this.timestamp = isVideo(image) ? image.currentTime : null;
+      this.timestamp =
+          isVideo(image) ? image.currentTime * SECOND_TO_MICRO_SECONDS : null;
     }
 
     const imageSize = getImageSize(image);

--- a/pose-detection/src/blazepose/detector_utils.ts
+++ b/pose-detection/src/blazepose/detector_utils.ts
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-import {DEFAULT_BLAZEPOSE_DETECTOR_MODEL_URL, DEFAULT_BLAZEPOSE_FULLBODY_CONFIG, DEFAULT_BLAZEPOSE_LANDMARK_FULL_BODY_MODEL_URL, DEFAULT_BLAZEPOSE_LANDMARK_UPPER_BODY_MODEL_URL} from './constants';
+import {DEFAULT_BLAZEPOSE_DETECTOR_MODEL_URL, DEFAULT_BLAZEPOSE_ESTIMATION_CONFIG, DEFAULT_BLAZEPOSE_FULLBODY_CONFIG, DEFAULT_BLAZEPOSE_LANDMARK_FULL_BODY_MODEL_URL, DEFAULT_BLAZEPOSE_LANDMARK_UPPER_BODY_MODEL_URL} from './constants';
 import {BlazeposeEstimationConfig, BlazeposeModelConfig} from './types';
 
 export function validateModelConfig(modelConfig: BlazeposeModelConfig):
@@ -53,7 +53,13 @@ export function validateModelConfig(modelConfig: BlazeposeModelConfig):
 
 export function validateEstimationConfig(
     estimationConfig: BlazeposeEstimationConfig): BlazeposeEstimationConfig {
-  const config = {...estimationConfig};
+  let config;
+
+  if (estimationConfig == null) {
+    config = DEFAULT_BLAZEPOSE_ESTIMATION_CONFIG;
+  } else {
+    config = {...estimationConfig};
+  }
 
   if (config.maxPoses == null) {
     config.maxPoses = 1;

--- a/pose-detection/src/movenet/detector.ts
+++ b/pose-detection/src/movenet/detector.ts
@@ -157,9 +157,9 @@ export class MoveNetDetector extends BasePoseDetector {
    *       enabled, a temporal smoothing filter will be used on the keypoint
    *       locations to reduce jitter.
    *
-   * @param timestamp Optional. In seconds. This is useful when image is a
-   *     tensor, which doesn't have timestamp info. Or to override timestamp in
-   *     a video.
+   * @param timestamp Optional. In microseconds, i.e. 1e-6 of a second. This is
+   *     useful when image is a tensor, which doesn't have timestamp info. Or
+   *     to override timestamp in a video.
    *
    * @return An array of `Pose`s.
    */

--- a/pose-detection/src/movenet/detector.ts
+++ b/pose-detection/src/movenet/detector.ts
@@ -150,20 +150,24 @@ export class MoveNetDetector extends BasePoseDetector {
    * ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement The input
    * image to feed through the network.
    *
-   * @param config
+   * @param config Optional.
    *       maxPoses: Optional. Has to be set to 1.
    *
    *       enableSmoothing: Optional. Optional. Defaults to 'true'. When
    *       enabled, a temporal smoothing filter will be used on the keypoint
    *       locations to reduce jitter.
    *
+   * @param timestamp Optional. In seconds. This is useful when image is a
+   *     tensor, which doesn't have timestamp info. Or to override timestamp in
+   *     a video.
+   *
    * @return An array of `Pose`s.
    */
   async estimatePoses(
       image: PoseDetectorInput,
       estimationConfig:
-          MoveNetEstimationConfig = MOVENET_SINGLE_POSE_ESTIMATION_CONFIG):
-      Promise<Pose[]> {
+          MoveNetEstimationConfig = MOVENET_SINGLE_POSE_ESTIMATION_CONFIG,
+      timestamp?: number): Promise<Pose[]> {
     estimationConfig = validateEstimationConfig(estimationConfig);
 
     if (image == null) {

--- a/pose-detection/src/pose_detector.ts
+++ b/pose-detection/src/pose_detector.ts
@@ -26,13 +26,17 @@ export interface PoseDetector {
   /**
    * Estimate poses for an image or video frame.
    * @param image An image or video frame.
-   * @param config See `EstimationConfig` for available options.
+   * @param config Optional. See `EstimationConfig` for available options.
+   * @param timestamp Optional. In seconds. This is useful when image is a
+   *     tensor, which doesn't have timestamp info. Or to override timestamp in
+   *     a video.
    * @returns An array of poses, each pose contains an array of `Keypoint`s.
    */
   estimatePoses(
       image: PoseDetectorInput,
       config?: PoseNetEstimationConfig|BlazeposeEstimationConfig|
-      MoveNetEstimationConfig): Promise<Pose[]>;
+      MoveNetEstimationConfig,
+      timestamp?: number): Promise<Pose[]>;
 
   /**
    * Dispose the underlying models from memory.
@@ -63,7 +67,8 @@ export abstract class BasePoseDetector implements PoseDetector {
   abstract estimatePoses(
       image: PoseDetectorInput,
       config?: PoseNetEstimationConfig|BlazeposeEstimationConfig|
-      MoveNetEstimationConfig): Promise<Pose[]>;
+      MoveNetEstimationConfig,
+      timestamp?: number): Promise<Pose[]>;
 
   abstract dispose(): void;
 

--- a/pose-detection/src/pose_detector.ts
+++ b/pose-detection/src/pose_detector.ts
@@ -27,9 +27,9 @@ export interface PoseDetector {
    * Estimate poses for an image or video frame.
    * @param image An image or video frame.
    * @param config Optional. See `EstimationConfig` for available options.
-   * @param timestamp Optional. In seconds. This is useful when image is a
-   *     tensor, which doesn't have timestamp info. Or to override timestamp in
-   *     a video.
+   * @param timestamp Optional. In microseconds, i.e. 1e-6 of a second. This is
+   *     useful when image is a tensor, which doesn't have timestamp info. Or
+   *     to override timestamp in a video.
    * @returns An array of poses, each pose contains an array of `Keypoint`s.
    */
   estimatePoses(

--- a/pose-detection/src/posenet/detector.ts
+++ b/pose-detection/src/posenet/detector.ts
@@ -120,9 +120,10 @@ export class PosenetDetector extends BasePoseDetector {
    *       flipHorizontal: Optional. Default to false. When image data comes
    *       from camera, the result has to flip horizontally.
    *
-   * @param timestamp Optional. In seconds. This is useful when image is a
-   *     tensor, which doesn't have timestamp info. Or to override timestamp in
-   *     a video.
+   * @param timestamp Optional. In microseconds, i.e. 1e-6 of a second. This is
+   *     useful when image is a tensor, which doesn't have timestamp info. Or
+   *     to override timestamp in a video.
+   *
    * @return An array of `Pose`s.
    */
   async estimatePoses(

--- a/pose-detection/src/posenet/detector.ts
+++ b/pose-detection/src/posenet/detector.ts
@@ -120,13 +120,16 @@ export class PosenetDetector extends BasePoseDetector {
    *       flipHorizontal: Optional. Default to false. When image data comes
    *       from camera, the result has to flip horizontally.
    *
+   * @param timestamp Optional. In seconds. This is useful when image is a
+   *     tensor, which doesn't have timestamp info. Or to override timestamp in
+   *     a video.
    * @return An array of `Pose`s.
    */
   async estimatePoses(
       image: PoseDetectorInput,
       estimationConfig:
-          PoseNetEstimationConfig = SINGLE_PERSON_ESTIMATION_CONFIG):
-      Promise<Pose[]> {
+          PoseNetEstimationConfig = SINGLE_PERSON_ESTIMATION_CONFIG,
+      timestamp?: number): Promise<Pose[]> {
     const config = validateEstimationConfig(estimationConfig);
 
     if (image == null) {


### PR DESCRIPTION
Allow timestamp as a user input. This is useful when image input is an imageTensor, which doesn't have timestamp information. Or when we want to override the timestamp from the video.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/648)
<!-- Reviewable:end -->
