### PR TITLE
fix(speech-commands): require util only when scheme is file

### DIFF
--- a/speech-commands/src/browser_fft_utils.ts
+++ b/speech-commands/src/browser_fft_utils.ts
@@ -16,7 +16,6 @@
  */
 
 import * as tf from '@tensorflow/tfjs-core';
-import {promisify} from 'util';
 
 import {RawAudioData} from './types';
 
@@ -32,6 +31,7 @@ export async function loadMetadataJson(url: string):
   } else if (url.indexOf(FILE_SCHEME) === 0) {
     // tslint:disable-next-line:no-require-imports
     const fs = require('fs');
+    const promisify = require("util").promisify;
     const readFile = promisify(fs.readFile);
 
     return JSON.parse(


### PR DESCRIPTION
Currently speech-commands imports util at top level. This does not work with some bundlers (like [Vite](https://vitejs.dev/)) which do not polyfill node built-ins.