### PR TITLE
[pose-detection]Change Blazepose fullbody and upperbody selection fro…

### DIFF
--- a/pose-detection/demo/src/index.js
+++ b/pose-detection/demo/src/index.js
@@ -37,9 +37,9 @@ async function createDetector() {
         inputResolution: {width: 500, height: 500},
         multiplier: 0.75
       });
-    case posedetection.SupportedModels.MediapipeBlazepose:
-      return posedetection.createDetector(
-          STATE.model.model, {quantBytes: 4, upperBodyOnly: false});
+    case posedetection.SupportedModels.MediapipeBlazeposeUpperBody:
+    case posedetection.SupportedModels.MediapipeBlazeposeFullBody:
+      return posedetection.createDetector(STATE.model.model, {quantBytes: 4});
     case posedetection.SupportedModels.MoveNet:
       const modelType = STATE.model.type == 'lightning' ?
           posedetection.movenet.modelType.SINGLEPOSE_LIGHTNING :

--- a/pose-detection/demo/src/option_panel.js
+++ b/pose-detection/demo/src/option_panel.js
@@ -15,6 +15,7 @@
  * =============================================================================
  */
 import * as posedetection from '@tensorflow-models/pose-detection';
+import {type} from 'os';
 
 import * as params from './params';
 
@@ -81,11 +82,25 @@ function addMoveNetControllers(modelFolder, type) {
 
 // The Blazepose model config folder contains options for Blazepose config
 // settings.
-function addBlazePoseControllers(modelFolder) {
-  params.STATE.model = {
-    model: posedetection.SupportedModels.MediapipeBlazepose,
-    ...params.BLAZEPOSE_CONFIG
-  };
+function addBlazePoseControllers(modelFolder, type) {
+  params.STATE.model = {...params.BLAZEPOSE_CONFIG};
+
+  params.STATE.model.model = type === 'upperbody' ?
+      posedetection.SupportedModels.MediapipeBlazeposeUpperBody :
+      posedetection.SupportedModels.MediapipeBlazeposeFullBody;
+  console.log(type);
+  console.log(params.STATE.model);
+  console.log(posedetection.SupportedModels);
+  params.STATE.model.type = type === 'upperbody' ? 'upperbody' : 'fullbody';
+
+  const typeController =
+      modelFolder.add(params.STATE.model, 'type', ['fullbody', 'upperbody']);
+  typeController.onChange(type => {
+    params.STATE.changeToModel = type;
+    params.STATE.model.model = type === 'upperbody' ?
+        posedetection.SupportedModels.MediapipeBlazeposeUpperBody :
+        posedetection.SupportedModels.MediapipeBlazeposeFullBody;
+  })
 
   modelFolder.add(params.STATE.model, 'scoreThreshold', 0, 1);
 }

--- a/pose-detection/demo/src/option_panel.js
+++ b/pose-detection/demo/src/option_panel.js
@@ -88,9 +88,7 @@ function addBlazePoseControllers(modelFolder, type) {
   params.STATE.model.model = type === 'upperbody' ?
       posedetection.SupportedModels.MediapipeBlazeposeUpperBody :
       posedetection.SupportedModels.MediapipeBlazeposeFullBody;
-  console.log(type);
-  console.log(params.STATE.model);
-  console.log(posedetection.SupportedModels);
+
   params.STATE.model.type = type === 'upperbody' ? 'upperbody' : 'fullbody';
 
   const typeController =

--- a/pose-detection/src/blazepose/constants.ts
+++ b/pose-detection/src/blazepose/constants.ts
@@ -15,11 +15,6 @@
  * =============================================================================
  */
 
-import {BlazeposeModelConfig} from './types';
-
-export const DEFAULT_BLAZEPOSE_FULLBODY_CONFIG: BlazeposeModelConfig = {
-  upperBodyOnly: false
-};
 export const DEFAULT_BLAZEPOSE_DETECTOR_MODEL_URL =
     'https://storage.googleapis.com/tfjs-models/savedmodel/blazepose/detector/model.json';
 export const DEFAULT_BLAZEPOSE_LANDMARK_FULL_BODY_MODEL_URL =

--- a/pose-detection/src/blazepose/detector.ts
+++ b/pose-detection/src/blazepose/detector.ts
@@ -57,7 +57,6 @@ type PoseLandmarkByRoiResult = {
  * Blazepose detector class.
  */
 export class BlazeposeDetector extends BasePoseDetector {
-  private readonly upperBodyOnly: boolean;
   private readonly anchors: Rect[];
   private readonly anchorTensor: AnchorTensor;
 
@@ -75,10 +74,8 @@ export class BlazeposeDetector extends BasePoseDetector {
   private constructor(
       private readonly detectorModel: tfconv.GraphModel,
       private readonly landmarkModel: tfconv.GraphModel,
-      config: BlazeposeModelConfig) {
+      private readonly upperBodyOnly: boolean) {
     super();
-
-    this.upperBodyOnly = config.upperBodyOnly;
 
     this.anchors =
         createSsdAnchors(constants.BLAZEPOSE_DETECTOR_ANCHOR_CONFIGURATION);
@@ -98,15 +95,16 @@ export class BlazeposeDetector extends BasePoseDetector {
    * the Blazepose loading process. Please find more details of each parameters
    * in the documentation of the `BlazeposeModelConfig` interface.
    */
-  static async load(modelConfig: BlazeposeModelConfig): Promise<PoseDetector> {
-    const config = validateModelConfig(modelConfig);
+  static async load(modelConfig: BlazeposeModelConfig, upperBodyOnly = false):
+      Promise<PoseDetector> {
+    const config = validateModelConfig(modelConfig, upperBodyOnly);
 
     const [detectorModel, landmarkModel] = await Promise.all([
       tfconv.loadGraphModel(config.detectorModelUrl),
       tfconv.loadGraphModel(config.landmarkModelUrl)
     ]);
 
-    return new BlazeposeDetector(detectorModel, landmarkModel, config);
+    return new BlazeposeDetector(detectorModel, landmarkModel, upperBodyOnly);
   }
 
   /**

--- a/pose-detection/src/blazepose/detector_utils.ts
+++ b/pose-detection/src/blazepose/detector_utils.ts
@@ -15,21 +15,18 @@
  * =============================================================================
  */
 
-import {DEFAULT_BLAZEPOSE_DETECTOR_MODEL_URL, DEFAULT_BLAZEPOSE_ESTIMATION_CONFIG, DEFAULT_BLAZEPOSE_FULLBODY_CONFIG, DEFAULT_BLAZEPOSE_LANDMARK_FULL_BODY_MODEL_URL, DEFAULT_BLAZEPOSE_LANDMARK_UPPER_BODY_MODEL_URL} from './constants';
+import {DEFAULT_BLAZEPOSE_DETECTOR_MODEL_URL, DEFAULT_BLAZEPOSE_ESTIMATION_CONFIG, DEFAULT_BLAZEPOSE_LANDMARK_FULL_BODY_MODEL_URL, DEFAULT_BLAZEPOSE_LANDMARK_UPPER_BODY_MODEL_URL} from './constants';
 import {BlazeposeEstimationConfig, BlazeposeModelConfig} from './types';
 
-export function validateModelConfig(modelConfig: BlazeposeModelConfig):
-    BlazeposeModelConfig {
+export function validateModelConfig(
+    modelConfig: BlazeposeModelConfig,
+    upperBodyOnly: boolean): BlazeposeModelConfig {
   let config;
 
   if (modelConfig == null) {
-    config = {...DEFAULT_BLAZEPOSE_FULLBODY_CONFIG};
+    config = {};
   } else {
     config = {...modelConfig};
-  }
-
-  if (config.upperBodyOnly == null) {
-    config.upperBodyOnly = false;
   }
 
   if (config.quantBytes == null) {
@@ -41,7 +38,7 @@ export function validateModelConfig(modelConfig: BlazeposeModelConfig):
   }
 
   if (config.landmarkModelUrl == null) {
-    if (config.upperBodyOnly) {
+    if (upperBodyOnly) {
       config.landmarkModelUrl = DEFAULT_BLAZEPOSE_LANDMARK_UPPER_BODY_MODEL_URL;
     } else {
       config.landmarkModelUrl = DEFAULT_BLAZEPOSE_LANDMARK_FULL_BODY_MODEL_URL;

--- a/pose-detection/src/blazepose/types.ts
+++ b/pose-detection/src/blazepose/types.ts
@@ -20,11 +20,6 @@ import {EstimationConfig, ModelConfig} from '../types';
 /**
  * Additional Blazepose model loading config.
  *
- * `upperBodyOnly`: Optional. Default to false. If upperBody is true, then the
- * detector only detects 25 keypoints of the upperbody. The upperbody model
- * has a higher accuracy for upperbody prediction than the fullbody model. If
- * upperBody is false, then the detector detects 33 keypoints of the full body.
- *
  * `detectorModelUrl`: Optional. An optional string that specifies custom url of
  * the detector model. This is useful for area/countries that don't have access
  * to the model hosted on GCP.
@@ -34,7 +29,6 @@ import {EstimationConfig, ModelConfig} from '../types';
  * to the model hosted on GCP.
  */
 export interface BlazeposeModelConfig extends ModelConfig {
-  upperBodyOnly?: boolean;
   lite?: boolean;
   detectorModelUrl?: string;
   landmarkModelUrl?: string;

--- a/pose-detection/src/constants.ts
+++ b/pose-detection/src/constants.ts
@@ -19,7 +19,7 @@ export const COCO_KEYPOINTS = [
   'rightShoulder', 'leftElbow', 'rightElbow', 'leftWrist', 'rightWrist',
   'leftHip', 'rightHip', 'leftKnee', 'rightKnee', 'leftAnkle', 'rightAnkle'
 ];
-export const BLAZEPOSE_KEYPOINTS_UPPERBODY = [
+export const BLAZEPOSE_KEYPOINTS_UPPER_BODY = [
   'nose',         'rightEyeInner', 'rightEye',     'rightEyeOuter',
   'leftEyeInner', 'leftEye',       'leftEyeOuter', 'rightEar',
   'leftEar',      'mouthRight',    'mouthLeft',    'rightShoulder',
@@ -28,13 +28,18 @@ export const BLAZEPOSE_KEYPOINTS_UPPERBODY = [
   'leftIndex',    'rightThumb',    'leftThumb',    'rightHip',
   'leftHip'
 ];
-export const BLAZEPOSE_KEYPOINTS_FULLBODY = [
-  ...BLAZEPOSE_KEYPOINTS_UPPERBODY, 'rightKnee', 'leftKnee', 'rightAnkle',
+export const BLAZEPOSE_KEYPOINTS_FULL_BODY = [
+  ...BLAZEPOSE_KEYPOINTS_UPPER_BODY, 'rightKnee', 'leftKnee', 'rightAnkle',
   'leftAnkle', 'rightHeel', 'leftHeel', 'rightFoot', 'leftFoot'
 ];
-export const BLAZEPOSE_KEYPOINTS_BY_SIDE = {
+export const BLAZEPOSE_KEYPOINTS_BY_SIDE_FULL_BODY = {
   left: [4, 5, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32],
   right: [1, 2, 3, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31],
+  middle: [0]
+};
+export const BLAZEPOSE_KEYPOINTS_BY_SIDE_UPPER_BODY = {
+  left: [4, 5, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24],
+  right: [1, 2, 3, 7, 9, 11, 13, 15, 17, 19, 21, 23],
   middle: [0]
 };
 export const COCO_KEYPOINTS_BY_SIDE = {
@@ -46,13 +51,19 @@ export const COCO_CONNECTED_KEYPOINTS_PAIRS = [
   [0, 1], [0, 2], [1, 3], [2, 4], [5, 6], [5, 7], [5, 11], [6, 8], [6, 12],
   [7, 9], [8, 10], [11, 12], [11, 13], [12, 14], [13, 15], [14, 16]
 ];
-export const BLAZEPOSE_CONNECTED_KEYPOINTS_PAIRS = [
+export const BLAZEPOSE_CONNECTED_KEYPOINTS_PAIRS_FULL_BODY = [
   [0, 1],   [0, 4],   [1, 2],   [2, 3],   [3, 7],   [4, 5],
   [5, 6],   [6, 8],   [9, 10],  [11, 12], [11, 13], [11, 23],
   [12, 14], [14, 16], [12, 24], [13, 15], [15, 17], [16, 18],
   [16, 20], [15, 17], [15, 19], [15, 21], [16, 22], [17, 19],
   [18, 20], [23, 25], [23, 24], [24, 26], [25, 27], [26, 28],
   [27, 29], [28, 30], [27, 31], [28, 32], [29, 31], [30, 32]
+];
+export const BLAZEPOSE_CONNECTED_KEYPOINTS_PAIRS_UPPER_BODY = [
+  [0, 1],   [0, 4],   [1, 2],   [2, 3],   [3, 7],   [4, 5],   [5, 6],
+  [6, 8],   [9, 10],  [11, 12], [11, 13], [11, 23], [12, 14], [14, 16],
+  [12, 24], [13, 15], [15, 17], [16, 18], [16, 20], [15, 17], [15, 19],
+  [15, 21], [16, 22], [17, 19], [18, 20], [23, 24]
 ];
 export const COCO_KEYPOINTS_NAMED_MAP: {[index: string]: number} = {
   nose: 0,

--- a/pose-detection/src/create_detector.ts
+++ b/pose-detection/src/create_detector.ts
@@ -36,7 +36,10 @@ export async function createDetector(
   switch (model) {
     case SupportedModels.PoseNet:
       return PosenetDetector.load(modelConfig as PosenetModelConfig);
-    case SupportedModels.MediapipeBlazepose:
+    case SupportedModels.MediapipeBlazeposeUpperBody:
+      return BlazeposeDetector.load(
+          modelConfig as BlazeposeModelConfig, true /* upperBodyOnly */);
+    case SupportedModels.MediapipeBlazeposeFullBody:
       return BlazeposeDetector.load(modelConfig as BlazeposeModelConfig);
     case SupportedModels.MoveNet:
       return MoveNetDetector.load(modelConfig as MoveNetModelConfig);

--- a/pose-detection/src/test_util.ts
+++ b/pose-detection/src/test_util.ts
@@ -136,15 +136,13 @@ function drawSkeleton(
   ctx.lineWidth = 2;
 
   poseDetection.util.getAdjacentPairs(model).forEach(([i, j]) => {
-    if (i < keypoints.length && j < keypoints.length) {
-      const kp1 = keypoints[i];
-      const kp2 = keypoints[j];
+    const kp1 = keypoints[i];
+    const kp2 = keypoints[j];
 
-      ctx.beginPath();
-      ctx.moveTo(kp1.x, kp1.y);
-      ctx.lineTo(kp2.x, kp2.y);
-      ctx.stroke();
-    }
+    ctx.beginPath();
+    ctx.moveTo(kp1.x, kp1.y);
+    ctx.lineTo(kp2.x, kp2.y);
+    ctx.stroke();
   });
 }
 

--- a/pose-detection/src/types.ts
+++ b/pose-detection/src/types.ts
@@ -18,7 +18,8 @@ import * as tf from '@tensorflow/tfjs-core';
 
 export enum SupportedModels {
   MoveNet = 'MoveNet',
-  MediapipeBlazepose = 'MediapipeBlazepose',
+  MediapipeBlazeposeFullBody = 'MediapipeBlazeposeFullBody',
+  MediapipeBlazeposeUpperBody = 'MediapipeBlazeposeUpperBody',
   PoseNet = 'PoseNet'
 }
 

--- a/pose-detection/src/util.ts
+++ b/pose-detection/src/util.ts
@@ -20,8 +20,10 @@ import {SupportedModels} from './types';
 export function getKeypointIndexBySide(model: SupportedModels):
     {left: number[], right: number[], middle: number[]} {
   switch (model) {
-    case SupportedModels.MediapipeBlazepose:
-      return constants.BLAZEPOSE_KEYPOINTS_BY_SIDE;
+    case SupportedModels.MediapipeBlazeposeUpperBody:
+      return constants.BLAZEPOSE_KEYPOINTS_BY_SIDE_UPPER_BODY;
+    case SupportedModels.MediapipeBlazeposeFullBody:
+      return constants.BLAZEPOSE_KEYPOINTS_BY_SIDE_FULL_BODY;
     case SupportedModels.PoseNet:
     case SupportedModels.MoveNet:
       return constants.COCO_KEYPOINTS_BY_SIDE;
@@ -31,8 +33,10 @@ export function getKeypointIndexBySide(model: SupportedModels):
 }
 export function getAdjacentPairs(model: SupportedModels): number[][] {
   switch (model) {
-    case SupportedModels.MediapipeBlazepose:
-      return constants.BLAZEPOSE_CONNECTED_KEYPOINTS_PAIRS;
+    case SupportedModels.MediapipeBlazeposeUpperBody:
+      return constants.BLAZEPOSE_CONNECTED_KEYPOINTS_PAIRS_UPPER_BODY;
+    case SupportedModels.MediapipeBlazeposeFullBody:
+      return constants.BLAZEPOSE_CONNECTED_KEYPOINTS_PAIRS_FULL_BODY;
     case SupportedModels.PoseNet:
     case SupportedModels.MoveNet:
       return constants.COCO_CONNECTED_KEYPOINTS_PAIRS;


### PR DESCRIPTION
This PR changes Blazepose fullbody and upperbody selection from a modelConfig option to enum option, which means fullbody and upperbody are two models. This is because the two models output different number of keypoints. There are code logic that is return keypoint array/map based on model (see util.ts). It is cleaner to decide on which keypoint representation just base on the model (enum) as oppose to basing on both model (enum) and config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/658)
<!-- Reviewable:end -->
