### PR TITLE
[pose-detection]Refactor code.

### DIFF
--- a/pose-detection/demo/src/index.js
+++ b/pose-detection/demo/src/index.js
@@ -56,26 +56,26 @@ async function createDetector() {
 }
 
 async function checkGuiUpdate() {
-  if (STATE.changeToTargetFPS || STATE.changeToSizeOption) {
+  if (STATE.isTargetFPSChanged || STATE.isSizeOptionChanged) {
     camera = await Camera.setupCamera(STATE.camera);
-    STATE.changeToTargetFPS = null;
-    STATE.changeToSizeOption = null;
+    STATE.isTargetFPSChanged = false;
+    STATE.isSizeOptionChanged = false;
   }
 
-  if (STATE.changeToModel != null) {
+  if (STATE.isModelChanged) {
     detector.dispose();
     detector = await createDetector(STATE.model);
-    STATE.changeToModel = null;
+    STATE.isModelChanged = false;
   }
 
   if (STATE.isFlagChanged || STATE.isBackendChanged) {
-    STATE.changeToModel = true;
+    STATE.isModelChanged = true;
     detector.dispose();
     await setBackendAndEnvFlags(STATE.flags, STATE.backend);
     detector = await createDetector(STATE.model);
     STATE.isFlagChanged = false;
     STATE.isBackendChanged = false;
-    STATE.changeToModel = null;
+    STATE.isModelChanged = false;
   }
 }
 
@@ -100,9 +100,9 @@ async function renderResult() {
   camera.drawCtx();
 
   // The null check makes sure the UI is not in the middle of changing to a
-  // different model. If changeToModel is non-null, the result is from an
-  // old model, which shouldn't be rendered.
-  if (poses.length > 0 && STATE.changeToModel == null) {
+  // different model. If during model change, the result is from an old model,
+  // which shouldn't be rendered.
+  if (poses.length > 0 && !STATE.isModelChanged) {
     camera.drawResults(poses);
   }
 }

--- a/pose-detection/demo/src/option_panel.js
+++ b/pose-detection/demo/src/option_panel.js
@@ -35,13 +35,13 @@ export async function setupDatGui(urlParams) {
   // The camera folder contains options for video settings.
   const cameraFolder = gui.addFolder('Camera');
   const fpsController = cameraFolder.add(params.STATE.camera, 'targetFPS');
-  fpsController.onFinishChange((targetFPS) => {
-    params.STATE.changeToTargetFPS = +targetFPS;
+  fpsController.onFinishChange((_) => {
+    params.STATE.isTargetFPSChanged = true;
   });
   const sizeController = cameraFolder.add(
       params.STATE.camera, 'sizeOption', Object.keys(params.VIDEO_SIZE));
-  sizeController.onChange(option => {
-    params.STATE.changeToSizeOption = option;
+  sizeController.onChange(_ => {
+    params.STATE.isSizeOptionChanged = true;
   });
   cameraFolder.open();
 
@@ -79,8 +79,8 @@ export async function setupDatGui(urlParams) {
   const modelController = modelFolder.add(
       params.STATE, 'model', Object.values(posedetection.SupportedModels));
 
-  modelController.onChange(model => {
-    params.STATE.changeToModel = model;
+  modelController.onChange(_ => {
+    params.STATE.isModelChanged = true;
     showModelConfigs(modelFolder);
   });
 
@@ -147,9 +147,9 @@ function addMoveNetControllers(modelConfigFolder, type) {
   const typeController = modelConfigFolder.add(
       params.STATE.modelConfig, 'type', ['thunder', 'lightning']);
   typeController.onChange(_ => {
-    // Set changeToModel to non-null, so that we don't render any result when
-    // changeToModel is non-null.
-    params.STATE.changeToModel = params.STATE.model;
+    // Set isModelChanged to true, so that we don't render any result during
+    // changing models.
+    params.STATE.isModelChanged = true;
   });
 
   modelConfigFolder.add(params.STATE.modelConfig, 'scoreThreshold', 0, 1);


### PR DESCRIPTION
This PR makes state update logic simpler. Instead of passing along changed value, it simply sets corresponding value change flag to true/false. When need to read the value, we can read directly from the value field, this is because onChange/onFinishChange event is fired after the value field is updated to new value. This refactor ensures:
(1) Value field is the only source of truth.
(2) All the value change flag fields are boolean, so that logic that are based on them can treat them as boolean without guessing. (Otherwise, some flag contains object, so need to check non-null, some flag contains boolean, so need to check truthy, etc.)