### PR TITLE
[pose-detection]Refactor ModelConfig and EstimationConfig.

### DIFF
--- a/pose-detection/src/blazepose/constants.ts
+++ b/pose-detection/src/blazepose/constants.ts
@@ -35,10 +35,15 @@ export const BLAZEPOSE_DETECTOR_ANCHOR_CONFIGURATION = {
   aspectRatios: [1.0],
   fixedAnchorSize: true
 };
+export const DEFAULT_BLAZEPOSE_MODEL_CONFIG = {
+  lite: false,
+  enableSmoothing: true,
+  detectorModelUrl: DEFAULT_BLAZEPOSE_DETECTOR_MODEL_URL,
+  landmarkModelUrl: DEFAULT_BLAZEPOSE_LANDMARK_MODEL_URL
+};
 export const DEFAULT_BLAZEPOSE_ESTIMATION_CONFIG = {
   maxPoses: 1,
-  flipHorizontal: false,
-  enableSmoothing: true
+  flipHorizontal: false
 };
 export const BLAZEPOSE_DETECTION_MODEL_INPUT_RESOLUTION = {
   width: 128,

--- a/pose-detection/src/blazepose/detector_utils.ts
+++ b/pose-detection/src/blazepose/detector_utils.ts
@@ -15,29 +15,28 @@
  * =============================================================================
  */
 
-import {DEFAULT_BLAZEPOSE_DETECTOR_MODEL_URL, DEFAULT_BLAZEPOSE_ESTIMATION_CONFIG, DEFAULT_BLAZEPOSE_LANDMARK_MODEL_URL} from './constants';
+import {DEFAULT_BLAZEPOSE_ESTIMATION_CONFIG, DEFAULT_BLAZEPOSE_MODEL_CONFIG} from './constants';
 import {BlazePoseEstimationConfig, BlazePoseModelConfig} from './types';
 
 export function validateModelConfig(modelConfig: BlazePoseModelConfig):
     BlazePoseModelConfig {
-  let config;
+  const config = modelConfig == null ? {...DEFAULT_BLAZEPOSE_MODEL_CONFIG} :
+                                       {...modelConfig};
 
-  if (modelConfig == null) {
-    config = {};
-  } else {
-    config = {...modelConfig};
+  if (config.enableSmoothing == null) {
+    config.enableSmoothing = DEFAULT_BLAZEPOSE_MODEL_CONFIG.enableSmoothing;
   }
 
-  if (config.quantBytes == null) {
-    config.quantBytes = 4;
+  if (config.lite == null) {
+    config.lite = DEFAULT_BLAZEPOSE_MODEL_CONFIG.lite;
   }
 
   if (config.detectorModelUrl == null) {
-    config.detectorModelUrl = DEFAULT_BLAZEPOSE_DETECTOR_MODEL_URL;
+    config.detectorModelUrl = DEFAULT_BLAZEPOSE_MODEL_CONFIG.detectorModelUrl;
   }
 
   if (config.landmarkModelUrl == null) {
-    config.landmarkModelUrl = DEFAULT_BLAZEPOSE_LANDMARK_MODEL_URL;
+    config.landmarkModelUrl = DEFAULT_BLAZEPOSE_MODEL_CONFIG.landmarkModelUrl;
   }
 
   return config;
@@ -65,10 +64,6 @@ export function validateEstimationConfig(
     throw new Error(
         'Multi-pose detection is not implemented yet. Please set maxPoses ' +
         'to 1.');
-  }
-
-  if (config.enableSmoothing == null) {
-    config.enableSmoothing = true;
   }
 
   return config;

--- a/pose-detection/src/blazepose/types.ts
+++ b/pose-detection/src/blazepose/types.ts
@@ -29,11 +29,10 @@ import {EstimationConfig, ModelConfig} from '../types';
  * to the model hosted on GCP.
  */
 export interface BlazePoseModelConfig extends ModelConfig {
+  enableSmoothing?: boolean;
   lite?: boolean;
   detectorModelUrl?: string;
   landmarkModelUrl?: string;
 }
 
-export interface BlazePoseEstimationConfig extends EstimationConfig {
-  enableSmoothing?: boolean;
-}
+export interface BlazePoseEstimationConfig extends EstimationConfig {}

--- a/pose-detection/src/posenet/types.ts
+++ b/pose-detection/src/posenet/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import {EstimationConfig, InputResolution, ModelConfig} from '../types';
+import {EstimationConfig, InputResolution, ModelConfig, QuantBytes} from '../types';
 
 export type PoseNetOutputStride = 32|16|8;
 export type PoseNetArchitecture = 'ResNet50'|'MobileNetV1';
@@ -52,6 +52,12 @@ export type MobileNetMultiplier = 0.50|0.75|1.0;
  * `modelUrl`: Optional. An optional string that specifies custom url of the
  * model. This is useful for area/countries that don't have access to the model
  * hosted on GCP.
+ *
+ * `quantBytes`: Optional. Options: 1, 2, or 4.  This parameter affects weight
+ * quantization in the models. The available options are
+ * 1 byte, 2 bytes, and 4 bytes. The higher the value, the larger the model size
+ * and thus the longer the loading time, the lower the value, the shorter the
+ * loading time but lower the accuracy.
  */
 export interface PosenetModelConfig extends ModelConfig {
   architecture: PoseNetArchitecture;
@@ -59,6 +65,7 @@ export interface PosenetModelConfig extends ModelConfig {
   inputResolution: InputResolution;
   multiplier?: MobileNetMultiplier;
   modelUrl?: string;
+  quantBytes?: QuantBytes;
 }
 
 /**

--- a/pose-detection/src/types.ts
+++ b/pose-detection/src/types.ts
@@ -26,16 +26,8 @@ export type QuantBytes = 1|2|4;
 
 /**
  * Common config to create the pose detector.
- *
- * `quantBytes`: Optional. Options: 1, 2, or 4.  This parameter affects weight
- * quantization in the models. The available options are
- * 1 byte, 2 bytes, and 4 bytes. The higher the value, the larger the model size
- * and thus the longer the loading time, the lower the value, the shorter the
- * loading time but lower the accuracy.
  */
-export interface ModelConfig {
-  quantBytes?: QuantBytes;
-}
+export interface ModelConfig {}
 
 /**
  * Common config for the `estimatePoses` method.


### PR DESCRIPTION
This PR has below changes:
1. Remove quantBytes as a common config for ModelConfig, because this is only used in PoseNet. In the future, if BlazePose and MoveNet want to provide quantized model, the custom modelUrl field should be sufficient.
2. Move enableSmoothing in BlazePose from estimationConfig to modelConfig, because smoothing filter has global state,and it cannot be changed between estimate calls.