### PR TITLE
Initialize MediaPipe solution during create_detector.

### DIFF
--- a/pose-detection/src/blazepose_mediapipe/detector.ts
+++ b/pose-detection/src/blazepose_mediapipe/detector.ts
@@ -37,7 +37,7 @@ export class BlazePoseMediaPipeDetector extends BasePoseDetector {
   private selfieMode = false;
 
   // Should not be called outside.
-  private constructor(config: BlazePoseMediaPipeModelConfig) {
+  constructor(config: BlazePoseMediaPipeModelConfig) {
     super();
     this.poseSolution = new pose.Pose({
       locateFile: (path, base) => {
@@ -53,12 +53,10 @@ export class BlazePoseMediaPipeDetector extends BasePoseDetector {
       case 'lite':
         modelComplexity = 0;
         break;
-      case 'full':
-        modelComplexity = 1;
-        break;
       case 'heavy':
         modelComplexity = 2;
         break;
+      case 'full':
       default:
         modelComplexity = 1;
         break;
@@ -84,19 +82,6 @@ export class BlazePoseMediaPipeDetector extends BasePoseDetector {
                                              score: landmark.visibility
                                            }))
     }];
-  }
-
-  /**
-   * Loads the MediaPipe solution.
-   *
-   * @param modelConfig ModelConfig dictionary that contains parameters for
-   * the BlazePose loading process. Please find more details of each parameters
-   * in the documentation of the `BlazePoseMediaPipeModelConfig` interface.
-   */
-  static async load(modelConfig: BlazePoseMediaPipeModelConfig):
-      Promise<PoseDetector> {
-    const config = validateModelConfig(modelConfig);
-    return new BlazePoseMediaPipeDetector(config);
   }
 
   /**
@@ -148,5 +133,24 @@ export class BlazePoseMediaPipeDetector extends BasePoseDetector {
 
   reset() {
     this.poseSolution.reset();
+  }
+
+  initialize(): Promise<void> {
+    return this.poseSolution.initialize();
+  }
+
+  /**
+   * Loads the MediaPipe solution.
+   *
+   * @param modelConfig ModelConfig dictionary that contains parameters for
+   * the BlazePose loading process. Please find more details of each parameters
+   * in the documentation of the `BlazePoseMediaPipeModelConfig` interface.
+   */
+  static async load(modelConfig: BlazePoseMediaPipeModelConfig):
+      Promise<PoseDetector> {
+    const config = validateModelConfig(modelConfig);
+    const result = new BlazePoseMediaPipeDetector(config);
+    await result.initialize();
+    return result;
   }
 }

--- a/pose-detection/src/create_detector.ts
+++ b/pose-detection/src/create_detector.ts
@@ -43,7 +43,7 @@ export async function createDetector(
       return config != null && config.runtime === 'tfjs' ?
           BlazePoseTfjsDetector.load(modelConfig as BlazePoseTfjsModelConfig) :
           BlazePoseMediaPipeDetector.load(
-              config as BlazePoseMediaPipeModelConfig);
+              modelConfig as BlazePoseMediaPipeModelConfig);
     case SupportedModels.MoveNet:
       return MoveNetDetector.load(modelConfig as MoveNetModelConfig);
     default:


### PR DESCRIPTION
Waiting until the first frame to initialize the solution causes
some frames to drop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/712)
<!-- Reviewable:end -->
