### PR TITLE
[pose-detection]timestamp change unit to milliseconds.

### DIFF
--- a/pose-detection/src/blazepose_mediapipe/detector.ts
+++ b/pose-detection/src/blazepose_mediapipe/detector.ts
@@ -105,9 +105,9 @@ class BlazePoseMediaPipeDetector implements PoseDetector {
    *       enableSmoothing: Optional. Default to true. Smooth pose landmarks
    *       coordinates and visibility scores to reduce jitter.
    *
-   * @param timestamp Optional. In microseconds, i.e. 1e-6 of a second. This is
-   *     useful when image is a tensor, which doesn't have timestamp info. Or
-   *     to override timestamp in a video.
+   * @param timestamp Optional. In milliseconds. This is useful when image is
+   *     a tensor, which doesn't have timestamp info. Or to override timestamp
+   *     in a video.
    *
    * @return An array of `Pose`s.
    */

--- a/pose-detection/src/blazepose_mediapipe/mediapipe_test.ts
+++ b/pose-detection/src/blazepose_mediapipe/mediapipe_test.ts
@@ -99,8 +99,8 @@ describeWithFlags('MediaPipe Pose video ', BROWSER_ENVS, () => {
 
     const callback = async(video: HTMLVideoElement, timestamp: number):
         Promise<poseDetection.Pose[]> => {
-          const poses = await detector.estimatePoses(
-              video, null /* config */, timestamp / 1000);
+          const poses =
+              await detector.estimatePoses(video, null /* config */, timestamp);
           result.push(poses[0].keypoints.map(kp => [kp.x, kp.y]));
           return poses;
         };

--- a/pose-detection/src/blazepose_tfjs/detector.ts
+++ b/pose-detection/src/blazepose_tfjs/detector.ts
@@ -19,7 +19,7 @@ import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
 import {BlazePoseModelType} from '../blazepose_mediapipe/types';
 
-import {SECOND_TO_MICRO_SECONDS} from '../calculators/constants';
+import {MILLISECOND_TO_MICRO_SECONDS, SECOND_TO_MICRO_SECONDS} from '../calculators/constants';
 import {convertImageToTensor} from '../calculators/convert_image_to_tensor';
 import {getImageSize, toImageTensor} from '../calculators/image_utils';
 import {ImageSize} from '../calculators/interfaces/common_interfaces';
@@ -105,9 +105,9 @@ class BlazePoseTfjsDetector implements PoseDetector {
    *       flipHorizontal: Optional. Default to false. When image data comes
    *       from camera, the result has to flip horizontally.
    *
-   * @param timestamp Optional. In microseconds, i.e. 1e-6 of a second. This is
-   *     useful when image is a tensor, which doesn't have timestamp info. Or
-   *     to override timestamp in a video.
+   * @param timestamp Optional. In milliseconds. This is useful when image is
+   *     a tensor, which doesn't have timestamp info. Or to override timestamp
+   *     in a video.
    *
    * @return An array of `Pose`s.
    */
@@ -128,7 +128,7 @@ class BlazePoseTfjsDetector implements PoseDetector {
 
     // User provided timestamp will override video's timestamp.
     if (timestamp != null) {
-      this.timestamp = timestamp;
+      this.timestamp = timestamp * MILLISECOND_TO_MICRO_SECONDS;
     } else {
       // For static images, timestamp should be null.
       this.timestamp =

--- a/pose-detection/src/calculators/constants.ts
+++ b/pose-detection/src/calculators/constants.ts
@@ -15,5 +15,5 @@
  * =============================================================================
  */
 export const MICRO_SECONDS_TO_SECOND = 1e-6;
-
 export const SECOND_TO_MICRO_SECONDS = 1e6;
+export const MILLISECOND_TO_MICRO_SECONDS = 1000;

--- a/pose-detection/src/movenet/detector.ts
+++ b/pose-detection/src/movenet/detector.ts
@@ -18,7 +18,7 @@
 import * as tfc from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
 
-import {SECOND_TO_MICRO_SECONDS} from '../calculators/constants';
+import {MILLISECOND_TO_MICRO_SECONDS, SECOND_TO_MICRO_SECONDS} from '../calculators/constants';
 import {getImageSize, toImageTensor} from '../calculators/image_utils';
 import {BoundingBox} from '../calculators/interfaces/shape_interfaces';
 import {isVideo} from '../calculators/is_video';
@@ -138,9 +138,9 @@ class MoveNetDetector implements PoseDetector {
    *  `enableSmoothing`: Optional. Defaults to `true`. When enabled, a temporal
    *  smoothing filter will be used on the keypoint locations to reduce jitter.
    *
-   * @param timestamp Optional. In microseconds, i.e. 1e-6 of a second. This is
-   * useful when image is a tensor, which doesn't have timestamp info. Or to
-   * override timestamp in a video.
+   * @param timestamp Optional. In milliseconds. This is useful when image is
+   *     a tensor, which doesn't have timestamp info. Or to override timestamp
+   *     in a video.
    *
    * @return An array of `Pose`s.
    */
@@ -156,8 +156,12 @@ class MoveNetDetector implements PoseDetector {
       return [];
     }
 
-    if (timestamp == null && isVideo(image)) {
-      timestamp = image.currentTime * SECOND_TO_MICRO_SECONDS;
+    if (timestamp == null) {
+      if (isVideo(image)) {
+        timestamp = image.currentTime * SECOND_TO_MICRO_SECONDS;
+      }
+    } else {
+      timestamp = timestamp * MILLISECOND_TO_MICRO_SECONDS;
     }
 
     const imageTensor3D = toImageTensor(image);

--- a/pose-detection/src/pose_detector.ts
+++ b/pose-detection/src/pose_detector.ts
@@ -28,9 +28,9 @@ export interface PoseDetector {
    * Estimate poses for an image or video frame.
    * @param image An image or video frame.
    * @param config Optional. See `EstimationConfig` for available options.
-   * @param timestamp Optional. In microseconds, i.e. 1e-6 of a second. This is
-   *     useful when image is a tensor, which doesn't have timestamp info. Or
-   *     to override timestamp in a video.
+   * @param timestamp Optional. In milliseconds. This is useful when image is
+   *     a tensor, which doesn't have timestamp info. Or to override timestamp
+   *     in a video.
    * @returns An array of poses, each pose contains an array of `Keypoint`s.
    */
   estimatePoses(

--- a/pose-detection/src/test_util.ts
+++ b/pose-detection/src/test_util.ts
@@ -17,7 +17,7 @@
 
 import * as poseDetection from './index';
 
-const SIMULATED_INTERVAL = 33333;  // in microseconds
+const SIMULATED_INTERVAL = 33.333;  // in milliseconds
 
 /** Karma server directory serving local files. */
 export const KARMA_SERVER = './base/src/test_data';


### PR DESCRIPTION
Change API's timestamp field unit to milliseconds, this is more common for web developers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/718)
<!-- Reviewable:end -->
