### PR TITLE
[pose-detection]Fix null case in BlazePose MediaPipe solution.

### DIFF
--- a/pose-detection/src/blazepose_mediapipe/detector.ts
+++ b/pose-detection/src/blazepose_mediapipe/detector.ts
@@ -73,14 +73,15 @@ class BlazePoseMediaPipeDetector implements PoseDetector {
   }
 
   private translateOutputs(results: pose.Results): Pose[] {
-    return [{
+    return results.poseLandmarks != null ? [{
       keypoints: results.poseLandmarks.map(landmark => ({
                                              x: landmark.x * this.width,
                                              y: landmark.y * this.height,
                                              z: landmark.z,
                                              score: landmark.visibility
                                            }))
-    }];
+    }] :
+                                           [];
   }
 
   /**


### PR DESCRIPTION
results.poseLandmarks could be null, fix the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/726)
<!-- Reviewable:end -->
