### PR TITLE
Update 404 Link for Coco Models

### DIFF
--- a/coco-ssd/README.md
+++ b/coco-ssd/README.md
@@ -129,7 +129,7 @@ Returns an array of classes and probabilities that looks like:
 
 ### Technical details for advanced users
 
-This model is based on the TensorFlow object detection API. You can download the original models from [here](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md#coco-trained-models). We applied the following optimizations to improve the performance for browser execution:
+This model is based on the TensorFlow object detection API. You can download the original models from [here](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf2_detection_zoo.md). We applied the following optimizations to improve the performance for browser execution:
 
   1. Removed the post process graph from the original model.
   2. Used single class NonMaxSuppression instead of original multiple classes NonMaxSuppression for faster speed with similar accuracy.


### PR DESCRIPTION
The current link redirects to a 404 page. This PR aims to redirect users to the new maintained README file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/755)
<!-- Reviewable:end -->
