### PR TITLE
[pose-detection] Update MoveNet models to v4

### DIFF
--- a/pose-detection/src/movenet/constants.ts
+++ b/pose-detection/src/movenet/constants.ts
@@ -23,9 +23,9 @@ export const SINGLEPOSE_THUNDER = 'SinglePose.Thunder';
 export const VALID_MODELS = [SINGLEPOSE_LIGHTNING, SINGLEPOSE_THUNDER];
 
 export const MOVENET_SINGLEPOSE_LIGHTNING_URL =
-    'https://tfhub.dev/google/tfjs-model/movenet/singlepose/lightning/3';
+    'https://tfhub.dev/google/tfjs-model/movenet/singlepose/lightning/4';
 export const MOVENET_SINGLEPOSE_THUNDER_URL =
-    'https://tfhub.dev/google/tfjs-model/movenet/singlepose/thunder/3';
+    'https://tfhub.dev/google/tfjs-model/movenet/singlepose/thunder/4';
 
 export const MOVENET_SINGLEPOSE_LIGHTNING_RESOLUTION = 192;
 export const MOVENET_SINGLEPOSE_THUNDER_RESOLUTION = 256;


### PR DESCRIPTION
Version 4 of the MoveNet Lightning and Thunder models were recently
released on TF Hub:

https://tfhub.dev/google/movenet/singlepose/lightning/4
https://tfhub.dev/google/movenet/singlepose/thunder/4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/760)
<!-- Reviewable:end -->
