### PR TITLE
[pose-detection]Allow MoveNet demo to swap model with customModel url…

### DIFF
--- a/pose-detection/demos/live_video/src/index.js
+++ b/pose-detection/demos/live_video/src/index.js
@@ -63,6 +63,9 @@ async function createDetector() {
       const modelType = STATE.modelConfig.type == 'lightning' ?
           posedetection.movenet.modelType.SINGLEPOSE_LIGHTNING :
           posedetection.movenet.modelType.SINGLEPOSE_THUNDER;
+      if (STATE.modelConfig.customModel !== '') {
+        return posedetection.createDetector(STATE.model, {modelType, modelUrl: STATE.modelConfig.customModel});
+      }
       return posedetection.createDetector(STATE.model, {modelType});
   }
 }

--- a/pose-detection/demos/live_video/src/index.js
+++ b/pose-detection/demos/live_video/src/index.js
@@ -64,7 +64,8 @@ async function createDetector() {
           posedetection.movenet.modelType.SINGLEPOSE_LIGHTNING :
           posedetection.movenet.modelType.SINGLEPOSE_THUNDER;
       if (STATE.modelConfig.customModel !== '') {
-        return posedetection.createDetector(STATE.model, {modelType, modelUrl: STATE.modelConfig.customModel});
+        return posedetection.createDetector(STATE.model, {modelType,
+          modelUrl: STATE.modelConfig.customModel});
       }
       return posedetection.createDetector(STATE.model, {modelType});
   }

--- a/pose-detection/demos/live_video/src/option_panel.js
+++ b/pose-detection/demos/live_video/src/option_panel.js
@@ -165,6 +165,11 @@ function addMoveNetControllers(modelConfigFolder, type) {
     params.STATE.isModelChanged = true;
   });
 
+  const customModelController = modelConfigFolder.add(params.STATE.modelConfig, 'customModel');
+  customModelController.onFinishChange(_ => {
+    params.STATE.isModelChanged = true;
+  })
+
   modelConfigFolder.add(params.STATE.modelConfig, 'scoreThreshold', 0, 1);
 }
 

--- a/pose-detection/demos/live_video/src/params.js
+++ b/pose-detection/demos/live_video/src/params.js
@@ -42,7 +42,8 @@ export const POSENET_CONFIG = {
 export const MOVENET_CONFIG = {
   maxPoses: 1,
   type: 'lightning',
-  scoreThreshold: 0.3
+  scoreThreshold: 0.3,
+  customModel: ''
 };
 /**
  * This map descripes tunable flags and theior corresponding types.

--- a/pose-detection/src/movenet/detector.ts
+++ b/pose-detection/src/movenet/detector.ts
@@ -483,8 +483,12 @@ export async function load(modelConfig: MoveNetModelConfig = MOVENET_CONFIG):
     Promise<PoseDetector> {
   const config = validateModelConfig(modelConfig);
   let model: tfc.GraphModel;
-  if (config.modelUrl) {
-    model = await tfc.loadGraphModel(config.modelUrl);
+
+  let fromTFHub = true;
+
+  if (!!config.modelUrl) {
+    fromTFHub = config.modelUrl.indexOf('https://tfhub.dev') > -1;
+    model = await tfc.loadGraphModel(config.modelUrl, {fromTFHub});
   } else {
     let modelUrl;
     if (config.modelType === SINGLEPOSE_LIGHTNING) {
@@ -492,7 +496,7 @@ export async function load(modelConfig: MoveNetModelConfig = MOVENET_CONFIG):
     } else if (config.modelType === SINGLEPOSE_THUNDER) {
       modelUrl = MOVENET_SINGLEPOSE_THUNDER_URL;
     }
-    model = await tfc.loadGraphModel(modelUrl, {fromTFHub: true});
+    model = await tfc.loadGraphModel(modelUrl, {fromTFHub});
   }
   return new MoveNetDetector(model, config);
 }


### PR DESCRIPTION
… in demo.

This PR adds a string field to the demo page under MoveNet's model parameter to allow users to provide a customModel url. The inputResolution is not exposed and is still decided by the modelType (i.e. thunder or lightning). The customModel should be compatible with the modelType.

This PR also fixes a bug, so that MoveNet can load custom models not from TFHub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/771)
<!-- Reviewable:end -->
