### PR TITLE
Add support for loading models from sources other than TFHub

### DIFF
--- a/toxicity/src/index.ts
+++ b/toxicity/src/index.ts
@@ -18,7 +18,9 @@
 import * as use from '@tensorflow-models/universal-sentence-encoder';
 import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
-export {version} from './version';
+export { version } from './version';
+
+const DEFAULT_MODEL_URI = 'https://tfhub.dev/tensorflow/tfjs-model/toxicity/1/default/1';
 
 declare interface ModelInputs extends tf.NamedTensorMap {
   Placeholder_1: tf.Tensor;
@@ -34,9 +36,12 @@ declare interface ModelInputs extends tf.NamedTensorMap {
  * to detect. Labels must be one of `toxicity` | `severe_toxicity` |
  * `identity_attack` | `insult` | `threat` | `sexual_explicit` | `obscene`.
  * Defaults to all labels.
+ * @param modelURI (optional) The URI of the model to be loaded
+ * @param modelOptions (optional) Options to be used when loading the model
+ *
  */
-export async function load(threshold: number, toxicityLabels: string[]) {
-  const model = new ToxicityClassifier(threshold, toxicityLabels);
+export async function load(threshold: number, toxicityLabels: string[], modelURI?: string, modelOptions?: object) {
+  const model = new ToxicityClassifier(threshold, toxicityLabels, modelURI, modelOptions);
   await model.load();
   return model;
 }
@@ -47,16 +52,20 @@ export class ToxicityClassifier {
   private labels: string[];
   private threshold: number;
   private toxicityLabels: string[];
+  private modelURI: string;
+  private modelOptions: object;
 
-  constructor(threshold = 0.85, toxicityLabels: string[] = []) {
+  constructor(threshold = 0.85, toxicityLabels: string[] = [], modelURI?: string, modelOptions?: object) {
     this.threshold = threshold;
     this.toxicityLabels = toxicityLabels;
+    this.modelURI = modelURI || DEFAULT_MODEL_URI;
+    this.modelOptions = modelOptions || { fromTFHub: this.modelURI == DEFAULT_MODEL_URI }
   }
 
   async loadModel() {
     return tfconv.loadGraphModel(
-        'https://tfhub.dev/tensorflow/tfjs-model/toxicity/1/default/1',
-        {fromTFHub: true});
+      this.modelURI,
+      this.modelOptions);
   }
 
   async loadTokenizer() {
@@ -65,22 +74,22 @@ export class ToxicityClassifier {
 
   async load() {
     const [model, tokenizer] =
-        await Promise.all([this.loadModel(), this.loadTokenizer()]);
+      await Promise.all([this.loadModel(), this.loadTokenizer()]);
 
     this.model = model;
     this.tokenizer = tokenizer;
 
     this.labels =
-        model.outputs.map((d: {name: string}) => d.name.split('/')[0]);
+      model.outputs.map((d: { name: string }) => d.name.split('/')[0]);
 
     if (this.toxicityLabels.length === 0) {
       this.toxicityLabels = this.labels;
     } else {
       tf.util.assert(
-          this.toxicityLabels.every(d => this.labels.indexOf(d) > -1),
-          () => `toxicityLabels argument must contain only items from the ` +
-              `model heads ${this.labels.join(', ')}, ` +
-              `got ${this.toxicityLabels.join(', ')}`);
+        this.toxicityLabels.every(d => this.labels.indexOf(d) > -1),
+        () => `toxicityLabels argument must contain only items from the ` +
+          `model heads ${this.labels.join(', ')}, ` +
+          `got ${this.toxicityLabels.join(', ')}`);
     }
   }
 
@@ -92,9 +101,9 @@ export class ToxicityClassifier {
    *
    * @param inputs A string or an array of strings to classify.
    */
-  async classify(inputs: string[]|string): Promise<Array<{
+  async classify(inputs: string[] | string): Promise<Array<{
     label: string,
-    results: Array<{probabilities: Float32Array, match: boolean}>
+    results: Array<{ probabilities: Float32Array, match: boolean }>
   }>> {
     if (typeof inputs === 'string') {
       inputs = [inputs];
@@ -105,16 +114,16 @@ export class ToxicityClassifier {
     // const encodings = inputs.map(d => padInput(this.tokenizer.encode(d)));
 
     const indicesArr =
-        encodings.map((arr, i) => arr.map((d, index) => [i, index]));
+      encodings.map((arr, i) => arr.map((d, index) => [i, index]));
 
     let flattenedIndicesArr: Array<[number, number]> = [];
     for (let i = 0; i < indicesArr.length; i++) {
       flattenedIndicesArr =
-          flattenedIndicesArr.concat(indicesArr[i] as Array<[number, number]>);
+        flattenedIndicesArr.concat(indicesArr[i] as Array<[number, number]>);
     }
 
     const indices = tf.tensor2d(
-        flattenedIndicesArr, [flattenedIndicesArr.length, 2], 'int32');
+      flattenedIndicesArr, [flattenedIndicesArr.length, 2], 'int32');
     const values = tf.tensor1d(tf.util.flatten(encodings) as number[], 'int32');
 
     const modelInputs: ModelInputs = {
@@ -128,25 +137,25 @@ export class ToxicityClassifier {
     values.dispose();
 
     return (labels as tf.Tensor2D[])
-        .map((d: tf.Tensor2D, i: number) => ({data: d, headIndex: i}))
-        .filter(
-            (d: {headIndex: number}) =>
-                this.toxicityLabels.indexOf(this.labels[d.headIndex]) > -1)
-        .map((d: {headIndex: number, data: tf.Tensor2D}) => {
-          const prediction = d.data.dataSync() as Float32Array;
-          const results = [];
-          for (let input = 0; input < inputs.length; input++) {
-            const probabilities = prediction.slice(input * 2, input * 2 + 2);
-            let match = null;
+      .map((d: tf.Tensor2D, i: number) => ({ data: d, headIndex: i }))
+      .filter(
+        (d: { headIndex: number }) =>
+          this.toxicityLabels.indexOf(this.labels[d.headIndex]) > -1)
+      .map((d: { headIndex: number, data: tf.Tensor2D }) => {
+        const prediction = d.data.dataSync() as Float32Array;
+        const results = [];
+        for (let input = 0; input < inputs.length; input++) {
+          const probabilities = prediction.slice(input * 2, input * 2 + 2);
+          let match = null;
 
-            if (Math.max(probabilities[0], probabilities[1]) > this.threshold) {
-              match = probabilities[0] < probabilities[1];
-            }
-
-            results.push({probabilities, match});
+          if (Math.max(probabilities[0], probabilities[1]) > this.threshold) {
+            match = probabilities[0] < probabilities[1];
           }
 
-          return {label: this.labels[d.headIndex], results};
-        });
+          results.push({ probabilities, match });
+        }
+
+        return { label: this.labels[d.headIndex], results };
+      });
   }
 }


### PR DESCRIPTION
Hi!
  I had a non-networked use case for the toxicity model, but it was fetched from TFHub each time it was loaded.  This small modification means that a different URI (and accompanying options) can be provided to support loading models from other sources, such as the local file system.  TFHub remains the default and the change is backwards compatible.

This is my first contribution to this project, so apologies if I missed anything. Feedback would be great.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/825)
<!-- Reviewable:end -->
