### PR TITLE
Remove minDetectionConfidence from hands config

### DIFF
--- a/hand-detection/src/mediapipe/types.ts
+++ b/hand-detection/src/mediapipe/types.ts
@@ -33,15 +33,11 @@ export interface MediaPipeHandsEstimationConfig extends EstimationConfig {}
  *
  * `solutionPath`: Optional. The path to where the wasm binary and model files
  * are located.
- *
- * `minDetectionConfidence`: Optional. Default to 0.5. Minimum confidence value
- * from the hand detection model for detection to be considered succesful.
  */
 export interface MediaPipeHandsMediaPipeModelConfig extends
     MediaPipeHandsModelConfig {
   runtime: 'mediapipe';
   solutionPath?: string;
-  minDetectionConfidence?: number;
 }
 
 /**


### PR DESCRIPTION
Removing the minDetectionConfidence due to @lina128 pointing out that users shouldn't need it to reject hands, they can use keypoint score to do so, which is more accurate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/836)
<!-- Reviewable:end -->
