### PR TITLE
Fix broken links to gifs

### DIFF
--- a/posenet/README.md
+++ b/posenet/README.md
@@ -6,7 +6,7 @@ This package contains a standalone model called PoseNet, as well as some demos, 
 
 [Try the demo here!](https://storage.googleapis.com/tfjs-models/demos/posenet/camera.html)
 
-<img src="demos/camera.gif" alt="cameraDemo" style="width: 600px;"/>
+<img src="demo/camera.gif" alt="cameraDemo" style="width: 600px;"/>
 
 PoseNet can be used to estimate either a single pose or multiple poses, meaning there is a version of the algorithm that can detect only one person in an image/video and one version that can detect multiple persons in an image/video.
 

--- a/posenet/demo/README.md
+++ b/posenet/demo/README.md
@@ -6,14 +6,14 @@
 
 The camera demo shows how to estimate poses in real-time from a webcam video stream.
 
-<img src="https://raw.githubusercontent.com/tensorflow/tfjs-models/master/posenet/demos/camera.gif" alt="cameraDemo" style="width: 600px;"/>
+<img src="camera.gif" alt="cameraDemo" style="width: 600px;"/>
 
 
 ### Demo 2: Coco Images
 
 The [coco images](http://cocodataset.org/#home) demo shows how to estimate poses in images. It also illustrates the differences between the single-person and multi-person pose detection algorithms.
 
-<img src="https://raw.githubusercontent.com/tensorflow/tfjs-models/master/posenet/demos/coco.gif" alt="cameraDemo" style="width: 600px;"/>
+<img src="coco.gif" alt="cameraDemo" style="width: 600px;"/>
 
 
 ## Setup


### PR DESCRIPTION
Folder `demos` was renamed to `demo`, which broke the links to the gifs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/845)
<!-- Reviewable:end -->
