### PR TITLE
Add lite hands model support to MediaPipe API

### DIFF
--- a/hand-detection/src/index.ts
+++ b/hand-detection/src/index.ts
@@ -19,7 +19,7 @@ export {createDetector} from './create_detector';
 // HandDetector class.
 export {HandDetector} from './hand_detector';
 // Entry point to create a new detector instance.
-export {MediaPipeHandsMediaPipeEstimationConfig, MediaPipeHandsMediaPipeModelConfig} from './mediapipe/types';
+export {MediaPipeHandsMediaPipeEstimationConfig, MediaPipeHandsMediaPipeModelConfig, MediaPipeHandsModelType} from './mediapipe/types';
 export {MediaPipeHandsTfjsEstimationConfig, MediaPipeHandsTfjsModelConfig} from './tfjs/types';
 
 // Supported models enum.

--- a/hand-detection/src/mediapipe/README.md
+++ b/hand-detection/src/mediapipe/README.md
@@ -52,6 +52,9 @@ Pass in `handDetection.SupportedModels.MediaPipeHands` from the
 
 *   *maxHands*: Defaults to 2. The maximum number of hands that will be detected by the model. The number of returned hands can be less than the maximum (for example when no hands are present in the input).
 
+*   *modelType*: specify which variant to load from `MediaPipeHandsModelType` (i.e.,
+    'lite', 'full'). If unset, the default is 'full'.
+
 *   *solutionPath*: The path to where the wasm binary and model files are located.
 
 ```javascript

--- a/hand-detection/src/mediapipe/constants.ts
+++ b/hand-detection/src/mediapipe/constants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_MPHANDS_MODEL_CONFIG:
     MediaPipeHandsMediaPipeModelConfig = {
       runtime: 'mediapipe',
       maxHands: 2,
+      modelType: 'full'
     };
 
 export const DEFAULT_MPHANDS_ESTIMATION_CONFIG:

--- a/hand-detection/src/mediapipe/detector.ts
+++ b/hand-detection/src/mediapipe/detector.ts
@@ -49,7 +49,18 @@ class MediaPipeHandsMediaPipeDetector implements HandDetector {
         return `${base}/${path}`;
       }
     });
+    let modelComplexity: 0|1;
+    switch (config.modelType) {
+      case 'lite':
+        modelComplexity = 0;
+        break;
+      case 'full':
+      default:
+        modelComplexity = 1;
+        break;
+    }
     this.handsSolution.setOptions({
+      modelComplexity,
       selfieMode: this.selfieMode,
       maxNumHands: config.maxHands,
     });

--- a/hand-detection/src/mediapipe/detector_utils.ts
+++ b/hand-detection/src/mediapipe/detector_utils.ts
@@ -33,6 +33,10 @@ export function validateModelConfig(
     config.maxHands = DEFAULT_MPHANDS_MODEL_CONFIG.maxHands;
   }
 
+  if (config.modelType == null) {
+    config.modelType = DEFAULT_MPHANDS_MODEL_CONFIG.modelType;
+  }
+
   return config;
 }
 

--- a/hand-detection/src/mediapipe/types.ts
+++ b/hand-detection/src/mediapipe/types.ts
@@ -17,11 +17,14 @@
 
 import {EstimationConfig, ModelConfig} from '../types';
 
+export type MediaPipeHandsModelType = 'lite'|'full';
+
 /**
  * Common MediaPipeHands model config.
  */
 export interface MediaPipeHandsModelConfig extends ModelConfig {
   runtime: 'mediapipe'|'tfjs';
+  modelType?: MediaPipeHandsModelType;
 }
 
 export interface MediaPipeHandsEstimationConfig extends EstimationConfig {}
@@ -30,6 +33,10 @@ export interface MediaPipeHandsEstimationConfig extends EstimationConfig {}
  * Model parameters for MediaPipeHands MediaPipe runtime
  *
  * `runtime`: Must set to be 'mediapipe'.
+ *
+ * `modelType`: Optional. Possible values: 'lite'|'full'. Defaults to
+ * 'full'. Landmark accuracy as well as inference latency generally go up with
+ * the increasing model complexity (lite to full).
  *
  * `solutionPath`: Optional. The path to where the wasm binary and model files
  * are located.

--- a/hand-detection/yarn.lock
+++ b/hand-detection/yarn.lock
@@ -882,9 +882,9 @@
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
 "@mediapipe/hands@^0.3.0":
-  version "0.3.1630010197"
-  resolved "https://registry.yarnpkg.com/@mediapipe/hands/-/hands-0.3.1630010197.tgz#60c6630a9d17481d91569fead6d57903da19d054"
-  integrity sha512-xSVWlV4zl3RXJod8+eO0o0QqLL83D94hcKSEm0lHVcQqufzBLo+Qaes20p0wj4c+UEHT7BNNNdUXk9L18r13/w==
+  version "0.3.1634603088"
+  resolved "https://registry.yarnpkg.com/@mediapipe/hands/-/hands-0.3.1634603088.tgz#6f65d0b05cccbcc5d0985e3ac2073465dea2a122"
+  integrity sha512-tL3qmM41gPMHe0jU3iM+u1oa2VPIUxSzRhDhedHQQaqdibFzbup3sPzsam3//7i2zkVnn39uCoWFMzQKdiGp4Q==
 
 "@rollup/plugin-commonjs@^11.0.2":
   version "11.1.0"


### PR DESCRIPTION
This adds forwarding to the model complexity config option added to mediapipe [hands web API](https://google.github.io/mediapipe/solutions/hands.html#model_complexity).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/846)
<!-- Reviewable:end -->
