### PR TITLE
fix: improve check for accessing token map in qna model

### DIFF
--- a/qna/src/question_and_answer.ts
+++ b/qna/src/question_and_answer.ts
@@ -274,7 +274,7 @@ class QuestionAndAnswerImpl implements QuestionAndAnswer {
     const origResults: AnswerIndex[] = [];
     startIndexes.forEach(start => {
       endIndexes.forEach(end => {
-        if (tokenToOrigMap[start] && tokenToOrigMap[end] && end >= start) {
+        if (tokenToOrigMap[start + OUTPUT_OFFSET] && tokenToOrigMap[end + OUTPUT_OFFSET] && end >= start) {
           const length = end - start + 1;
           if (length < MAX_ANSWER_LEN) {
             origResults.push(

--- a/qna/src/question_and_answer_test.ts
+++ b/qna/src/question_and_answer_test.ts
@@ -117,8 +117,8 @@ describeWithFlags('qna', NODE_ENVS, () => {
       {text: 'answer', score: 60, startIndex: 8, endIndex: 14},
       {text: 'answer for', score: 50, startIndex: 8, endIndex: 18},
       {text: 'answer for you!', score: 50, startIndex: 8, endIndex: 23},
-      {text: 'for', score: 40, startIndex: 15, endIndex: 18},
-      {text: 'for you!', score: 40, startIndex: 15, endIndex: 23}
+      {text: 'is answer', score: 50, startIndex: 5, endIndex: 14},
+      {text: 'is', score: 40, startIndex: 5, endIndex: 7}
     ]);
   });
 });


### PR DESCRIPTION
This commit has a small fix in the qna model function
getBestAnswers to protect the calls to convertBack so that it is
only called with indexes that can be found in tokenToOrigMap.

I needed to update the test to reflect the new behaviour.

Contributes to: tensorflow/tfjs#5946

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/888)
<!-- Reviewable:end -->
