### PR TITLE
BlazePose left_eye typo fix

### DIFF
--- a/pose-detection/README.md
+++ b/pose-detection/README.md
@@ -137,7 +137,7 @@ See the diagram below for what those keypoints are and their index in the array.
 
 0: nose  \
 1: left_eye_inner \
-2: left  \
+2: left_eye  \
 3: left_eye_outer  \
 4: right_eye_inner  \
 5: right_eye  \


### PR DESCRIPTION
Hi! I found typo on ReadMe BlazePose model!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/892)
<!-- Reviewable:end -->
