### PR TITLE
Move detector inference model call to outside function

### DIFF
--- a/hand-pose-detection/src/tfjs/detector.ts
+++ b/hand-pose-detection/src/tfjs/detector.ts
@@ -238,11 +238,12 @@ class MediaPipeHandsTfjsDetector implements HandDetector {
     const {imageTensor: imageValueShifted, padding} = convertImageToTensor(
         image, constants.MPHANDS_DETECTOR_IMAGE_TO_TENSOR_CONFIG);
 
+    const detectionResult =
+        this.detectorModel.predict(imageValueShifted) as tf.Tensor3D;
     // PalmDetectionCpu: InferenceCalculator
     // The model returns a tensor with the following shape:
     // [1 (batch), 896 (anchor points), 19 (data for each anchor)]
-    const {boxes, logits} =
-        detectorInference(imageValueShifted, this.detectorModel);
+    const {boxes, logits} = detectorInference(detectionResult);
 
     // PalmDetectionCpu: TensorsToDetectionsCalculator
     const detections: Detection[] = await tensorsToDetections(
@@ -250,7 +251,7 @@ class MediaPipeHandsTfjsDetector implements HandDetector {
         constants.MPHANDS_TENSORS_TO_DETECTION_CONFIGURATION);
 
     if (detections.length === 0) {
-      tf.dispose([imageValueShifted, logits, boxes]);
+      tf.dispose([imageValueShifted, detectionResult, logits, boxes]);
       return detections;
     }
 
@@ -265,7 +266,7 @@ class MediaPipeHandsTfjsDetector implements HandDetector {
     // PalmDetectionCpu: DetectionLetterboxRemovalCalculator
     const newDetections = removeDetectionLetterbox(selectedDetections, padding);
 
-    tf.dispose([imageValueShifted, logits, boxes]);
+    tf.dispose([imageValueShifted, detectionResult, logits, boxes]);
 
     return newDetections;
   }

--- a/shared/calculators/detector_inference.ts
+++ b/shared/calculators/detector_inference.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  * =============================================================================
  */
-import * as tfconv from '@tensorflow/tfjs-converter';
 import * as tf from '@tensorflow/tfjs-core';
 import {splitDetectionResult} from './split_detection_result';
 
@@ -23,12 +22,9 @@ export type DetectorInferenceResult = {
   logits: tf.Tensor1D
 };
 
-export function detectorInference(
-    imageTensor: tf.Tensor4D,
-    poseDetectorModel: tfconv.GraphModel): DetectorInferenceResult {
+export function detectorInference(detectionResult: tf.Tensor3D):
+    DetectorInferenceResult {
   return tf.tidy(() => {
-    const detectionResult =
-        poseDetectorModel.predict(imageTensor) as tf.Tensor3D;
     const [logits, rawBoxes] = splitDetectionResult(detectionResult);
     // Shape [896, 12]
     const rawBoxes2d = tf.squeeze(rawBoxes);


### PR DESCRIPTION
Needed for face detection tfjs implementation (#912) since it has multiple outputs so the relevant output has to be extracted before calling the function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/913)
<!-- Reviewable:end -->
