### PR TITLE
[toxicity] Arguments of `toxicity.load()` should be optional

### DIFF
--- a/toxicity/src/index.ts
+++ b/toxicity/src/index.ts
@@ -35,7 +35,7 @@ declare interface ModelInputs extends tf.NamedTensorMap {
  * `identity_attack` | `insult` | `threat` | `sexual_explicit` | `obscene`.
  * Defaults to all labels.
  */
-export async function load(threshold: number, toxicityLabels: string[]) {
+export async function load(threshold?: number, toxicityLabels?: string[]) {
   const model = new ToxicityClassifier(threshold, toxicityLabels);
   await model.load();
   return model;


### PR DESCRIPTION
This is a very minor TypeScript fix.

The arguments `threshold` and `toxicityLabels` are optional when calling `new ToxicityClassifier()`; but they are incorrectly marked as required on the exported `load()` function.

This PR adds two question marks to fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/969)
<!-- Reviewable:end -->
