### PR TITLE
Support custom model URL

### DIFF
--- a/toxicity/src/index.ts
+++ b/toxicity/src/index.ts
@@ -34,9 +34,13 @@ declare interface ModelInputs extends tf.NamedTensorMap {
  * to detect. Labels must be one of `toxicity` | `severe_toxicity` |
  * `identity_attack` | `insult` | `threat` | `sexual_explicit` | `obscene`.
  * Defaults to all labels.
+ * @param modelURL Load a model from URL rather than tfhub.dev
+ * Default is tfhub.dev.
  */
-export async function load(threshold: number, toxicityLabels: string[]) {
+export async function load(threshold: number, toxicityLabels: string[],
+    modelURL: 'https://tfhub.dev/tensorflow/tfjs-model/toxicity/1/default/1') {
   const model = new ToxicityClassifier(threshold, toxicityLabels);
+  model.setModelURL(modelURL);
   await model.load();
   return model;
 }
@@ -47,16 +51,19 @@ export class ToxicityClassifier {
   private labels: string[];
   private threshold: number;
   private toxicityLabels: string[];
+  private modelURL: string;
 
   constructor(threshold = 0.85, toxicityLabels: string[] = []) {
     this.threshold = threshold;
     this.toxicityLabels = toxicityLabels;
   }
 
+  setModelURL(url: string) {
+    this.modelURL = url
+  }
+
   async loadModel() {
-    return tfconv.loadGraphModel(
-        'https://tfhub.dev/tensorflow/tfjs-model/toxicity/1/default/1',
-        {fromTFHub: true});
+    return tfconv.loadGraphModel(this.modelURL, {fromTFHub: true});
   }
 
   async loadTokenizer() {


### PR DESCRIPTION
I want to load a local model rather than tfhub.dev to improve the loading performance. But I can not load model except from tfhub.dev, so I make this patch to make it work, if there's another way to make it let me know, thank you in advance :)