### PR TITLE
Fix blazeface memory leak

### DIFF
--- a/blazeface/src/blazeface_test.ts
+++ b/blazeface/src/blazeface_test.ts
@@ -24,6 +24,8 @@ import * as blazeface from './index';
 import {stubbedImageVals} from './test_util';
 
 describeWithFlags('BlazeFace', NODE_ENVS, () => {
+  const startTensors = tf.memory().numTensors;
+
   let model: BlazeFaceModel;
   beforeAll(async () => {
     model = await blazeface.load();
@@ -48,5 +50,10 @@ describeWithFlags('BlazeFace', NODE_ENVS, () => {
     expect(face.bottomRight).toBeDefined();
     expect(face.landmarks).toBeDefined();
     expect(face.probability).toBeDefined();
+  });
+
+  it('BlazeFace initialization does not leak memory', async () => {
+    model.dispose();
+    expect(tf.memory().numTensors).toEqual(startTensors);
   });
 });

--- a/blazeface/src/face.ts
+++ b/blazeface/src/face.ts
@@ -439,8 +439,8 @@ export class BlazeFaceModel {
    * Dispose the WebGL memory held by the underlying model.
    */
   dispose(): void {
-    if (this.blazeFaceModel != null) {
-      this.blazeFaceModel.dispose();
-    }
+    this.blazeFaceModel.dispose();
+    this.anchors.dispose();
+    this.inputSize.dispose();
   }
 }


### PR DESCRIPTION
Hi tfjs team 👋!

This PR fixes two memory leaks in blazeface - hopefully this is helpful even though it's deprecated.

I can confirm (at least in terms of allocated tensors) that there aren't any more leaks.  I also removed an unnecessary null check from the previous PR that added the `dispose()` method.

Is there any chance these changes could be pushed to `npm`?  I'd be happy to switch to the new face detection engine but that detector doesn't return a probability / confidence AFAIK and this functionality is required for my work.

Thanks for all your work and your willingness to open source this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/1038)
<!-- Reviewable:end -->
