### PR TITLE
Allow locateFile to be specified directly

### DIFF
--- a/body-segmentation/src/selfie_segmentation_mediapipe/README.md
+++ b/body-segmentation/src/selfie_segmentation_mediapipe/README.md
@@ -68,6 +68,9 @@ Pass in `bodySegmentation.SupportedModels.MediaPipeSelfieSegmentation` from the
     'general', 'landscape'). If unset, the default is 'general'.
 
 *   *solutionPath*: The path to where the wasm binary and model files are located.
+*   *locateFile*: The function to return URLs of the wasm binary and  model files.
+If specified at the same time as solutionPath, solutionPath is ignored.
+
 
 ```javascript
 const model = bodySegmentation.SupportedModels.MediaPipeSelfieSegmentation;

--- a/body-segmentation/src/selfie_segmentation_mediapipe/segmenter.ts
+++ b/body-segmentation/src/selfie_segmentation_mediapipe/segmenter.ts
@@ -71,7 +71,7 @@ class MediaPipeSelfieSegmentationMediaPipeSegmenter implements BodySegmenter {
         return `${solutionPath}/${path}`;
       }
       return `${base}/${path}`;
-    }
+    };
     this.selfieSegmentationSolution =
       new selfieSegmentation.SelfieSegmentation({
         locateFile: config.locateFile ?? solutionPathLocateFile

--- a/body-segmentation/src/selfie_segmentation_mediapipe/segmenter.ts
+++ b/body-segmentation/src/selfie_segmentation_mediapipe/segmenter.ts
@@ -65,16 +65,17 @@ class MediaPipeSelfieSegmentationMediaPipeSegmenter implements BodySegmenter {
 
   // Should not be called outside.
   constructor(config: MediaPipeSelfieSegmentationMediaPipeModelConfig) {
+    const solutionPathLocateFile = (path: string, base: string): string => {
+      if (config.solutionPath) {
+        const solutionPath = config.solutionPath.replace(/\/+$/, '');
+        return `${solutionPath}/${path}`;
+      }
+      return `${base}/${path}`;
+    }
     this.selfieSegmentationSolution =
-        new selfieSegmentation.SelfieSegmentation({
-          locateFile: (path, base) => {
-            if (config.solutionPath) {
-              const solutionPath = config.solutionPath.replace(/\/+$/, '');
-              return `${solutionPath}/${path}`;
-            }
-            return `${base}/${path}`;
-          }
-        });
+      new selfieSegmentation.SelfieSegmentation({
+        locateFile: config.locateFile ?? solutionPathLocateFile
+      });
     let modelSelection: 0|1;
     switch (config.modelType) {
       case 'landscape':

--- a/body-segmentation/src/selfie_segmentation_mediapipe/types.ts
+++ b/body-segmentation/src/selfie_segmentation_mediapipe/types.ts
@@ -42,12 +42,15 @@ export interface MediaPipeSelfieSegmentationSegmentationConfig extends
  *
  * `solutionPath`: Optional. The path to where the wasm binary and model files
  * are located.
+ * `locateFile`: Optional. The function to return URLs of the wasm binary and
+ * model files. If specified at the same time as solutionPath,
+ * solutionPath is ignored.
  */
 export interface MediaPipeSelfieSegmentationMediaPipeModelConfig extends
     MediaPipeSelfieSegmentationModelConfig {
   runtime: 'mediapipe';
   solutionPath?: string;
-  locateFile?: (path: string, base: string) => string;
+  locateFile?: (path: string, prefix?: string) => string;
 }
 
 /**

--- a/body-segmentation/src/selfie_segmentation_mediapipe/types.ts
+++ b/body-segmentation/src/selfie_segmentation_mediapipe/types.ts
@@ -47,6 +47,7 @@ export interface MediaPipeSelfieSegmentationMediaPipeModelConfig extends
     MediaPipeSelfieSegmentationModelConfig {
   runtime: 'mediapipe';
   solutionPath?: string;
+  locateFile?: (path: string, base: string) => string;
 }
 
 /**


### PR DESCRIPTION
What is better about this one is that it allows you to manage files directly in Bundler.

When combined with vite3, it looks like this

```typescript
import {
  BodySegmenter,
  SupportedModels,
  createSegmenter 
} from '@tensorflow-models/body-segmentation'


const selfieSegmentationmodulesMap = async ()=> {
  const modules = import.meta.glob('../../node_modules/@mediapipe/selfie_segmentation/*', { as: 'url' })
  const ret:[string, string][] = []
  for (const entry of Object.entries(modules)) {
    ret.push([entry[0].split('/').pop() || '', await entry[1]()])
  }
  return Object.fromEntries(ret)
}


export const createMediapipeSegmenter = async (): Promise<BodySegmenter> => {
  const modulesMap = await selfieSegmentationmodulesMap()
  const model = SupportedModels.MediaPipeSelfieSegmentation
  return createSegmenter(model, {
    runtime: 'mediapipe',
    modelType: 'general',
    locateFile: (file) => {
      return modulesMap[file]
    }
  })
}

```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/1039)
<!-- Reviewable:end -->
