### PR TITLE
updated broken image link in the hand-pose-detection documentation

### DIFF
--- a/hand-pose-detection/README.md
+++ b/hand-pose-detection/README.md
@@ -92,7 +92,7 @@ and their performance.
 See the diagram below for what those keypoints are and their index in the array.
 
 ### MediaPipe Hands Keypoints: Used in MediaPipe Hands
-![MediaPipeHands Keypoints](https://google.github.io/mediapipe/images/mobile/hand_landmarks.png)
+![MediaPipeHands Keypoints](https://mediapipe.dev/images/mobile/hand_landmarks.png)
 0: wrist  \
 1: thumb_cmc \
 2: thumb_mcp  \


### PR DESCRIPTION
A link to an image on the hand-pose-detection documentation was broken. I updated it with a new url which matches the url of the original, except it's from 'mediapipe.dev' instead of 'google.github.io'.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/1040)
<!-- Reviewable:end -->
