### PR TITLE
Set webgl and webgpu as external

### DIFF
--- a/pose-detection/rollup.config.js
+++ b/pose-detection/rollup.config.js
@@ -57,7 +57,9 @@ function config({plugins = [], output = {}, tsCompilerOptions = {}}) {
       ...output,
     },
     external: [
-      '@tensorflow/tfjs-core', '@tensorflow/tfjs-converter', '@mediapipe/pose'
+      '@tensorflow/tfjs-core', '@tensorflow/tfjs-converter',
+      '@tensorflow/tfjs-backend-webgpu', '@tensorflow/tfjs-backend-webgl',
+      '@mediapipe/pose'
     ]
   };
 }

--- a/pose-detection/rollup.config.js
+++ b/pose-detection/rollup.config.js
@@ -50,7 +50,9 @@ function config({plugins = [], output = {}, tsCompilerOptions = {}}) {
       banner: PREAMBLE,
       globals: {
         '@tensorflow/tfjs-core': 'tf',
-        '@tensorflow/tfjs-converter': 'tf',
+        '@tensorflow/tfjs-converter': 'tfconv',
+        '@tensorflow/tfjs-backend-webgpu': 'tfwebgpu',
+        '@tensorflow/tfjs-backend-webgl': 'tfwebgl',
         // Package is obfuscated so class is directly attached to globalThis.
         '@mediapipe/pose': 'globalThis'
       },


### PR DESCRIPTION
This fixes the duplicated kernel registration problem.

The production code will include code from other package when: package is imported(such as import * as tfwebgpu from '@tensorflow/tfjs-backend-webgpu';) and is non external in rollup.config.js.

Pose-detection will include a copy of tfjs-backend-webgpu.js(it is imported and is non external). E2e also loads tfjs-backend-webgpu.js with <script> tag. The two tfjs-backend-webgpu.js cannot be understood as the same package, so it will load twice.

Bug: https://github.com/tensorflow/tfjs/issues/7521

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/1140)
<!-- Reviewable:end -->
