### PR TITLE
[Text-Toxicity] Fix description for model usage

### DIFF
--- a/toxicity/README.md
+++ b/toxicity/README.md
@@ -48,7 +48,7 @@ toxicity.load(threshold).then(model => {
   model.classify(sentences).then(predictions => {
     // `predictions` is an array of objects, one for each prediction head,
     // that contains the raw probabilities for each input along with the
-    // final prediction in `match` (either `true` or `false`).
+    // final prediction in `match` (either `false` or `true`).
     // If neither prediction exceeds the threshold, `match` is `null`.
 
     console.log(predictions);

--- a/toxicity/src/index.ts
+++ b/toxicity/src/index.ts
@@ -86,7 +86,8 @@ export class ToxicityClassifier {
 
   /**
    * Returns an array of objects, one for each label, that contains
-   * the raw probabilities for each input along with the final prediction
+   * the raw probabilities (the first probability is for 'false', while the
+   * second is for 'true') for each input along with the final prediction
    * boolean given the threshold. If a prediction falls below the threshold,
    * `null` is returned.
    *


### PR DESCRIPTION
In  the [readme](https://github.com/tensorflow/tfjs-models/tree/master/toxicity#usage) of Text-toxicity's example, for each category, there are two numbers indicating the probabilities of `false` and `true` for whether the input matches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-models/1142)
<!-- Reviewable:end -->
