### PR TITLE
Add option to save coco-ssd model after load with `saveUrl`

### DIFF
--- a/coco-ssd/demo/index.js
+++ b/coco-ssd/demo/index.js
@@ -24,7 +24,7 @@ import image2URL from './image2.jpg';
 
 let modelPromise;
 
-window.onload = () => modelPromise = cocoSsd.load();
+window.onload = () => modelPromise = cocoSsd.load({ saveUrl: "indexeddb://model" });
 
 const button = document.getElementById('toggle');
 button.onclick = () => {


### PR DESCRIPTION
Alter coco-ssd model loader with an option to save the model. This allows for the model to be saved to local storage, IndexedDB ect, after first load.

See updated demo for an example.