### PR TITLE
Add 'skipLibCheck=true' to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "noUnusedParameters": false,
     "pretty": true,
     "noFallthroughCasesInSwitch": true,
-    "allowUnreachableCode": false
+    "allowUnreachableCode": false,
+    "skipLibCheck": true
   },
   "include": [
     "src/"


### PR DESCRIPTION
Fixes an issue where the WebGPU backend is referencing types that are not available. @types/dom-webcodecs could be added to the WebGPU backend, but this could potentially cause conflicts as types from that package are added to lib/dom, e.g.:

```
node_modules/typescript/lib/lib.dom.d.ts:28200:6 - error TS2300: Duplicate identifier 'VideoPixelFormat'.

28200 type VideoPixelFormat = "BGRA" | "BGRX" | "I420" | "I420A" | "I422" | "I444" | "NV12" | "RGBA" | "RGBX";
           ~~~~~~~~~~~~~~~~

  node_modules/@types/dom-webcodecs/webcodecs.generated.d.ts:416:6
    416 type VideoPixelFormat = "BGRA" | "BGRX" | "I420" | "I420A" | "I422" | "I444" | "NV12" | "RGBA" | "RGBX";
             ~~~~~~~~~~~~~~~~
    'VideoPixelFormat' was also declared here.
```

Consequently, I think it's best to just set `skipLibCheck` here.