### PR TITLE
Update broken link for speech_commands dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ and can be used as building blocks in other apps.
     <td rowspan="2"><b>Audio</b></td>
     <td rowspan="2"><b><a style="white-space:nowrap; display:inline-block;" href="./speech-commands"><div style='vertical-align:middle; display:inline;'>Speech Commands</div></a></b></td>
     <td><a href="https://storage.googleapis.com/tfjs-speech-model-test/2019-01-03a/dist/index.html">live</a></td>
-    <td rowspan="2">Classify 1 second audio snippets from the <a href="https://www.tensorflow.org/tutorials/sequences/audio_recognition">speech commands dataset</a>.</td>
+    <td rowspan="2">Classify 1 second audio snippets from the <a href="https://www.tensorflow.org/tutorials/audio/simple_audio">speech commands dataset</a>.</td>
     <td rowspan="2"><code>npm i @tensorflow-models/speech-commands</code></td>
   </tr>
   <tr>


### PR DESCRIPTION
I've identified and addressed a broken link to the [speech commands dataset](https://www.tensorflow.org/tutorials/sequences/audio_recognition) within the tfjs-models [table](https://github.com/tensorflow/tfjs-models?tab=readme-ov-file#models) for [speech commands dataset](https://www.tensorflow.org/tutorials/sequences/audio_recognition) for the audio type speech commands model. I've replaced the non-functional link with this more relevant and current resource: https://www.tensorflow.org/tutorials/audio/simple_audio so either we can directly point to [speech commands dataset ](https://www.tensorflow.org/datasets/catalog/speech_commands) or replace with this link :https://www.tensorflow.org/tutorials/audio/simple_audio

Please review the change and provide any feedback or suggestions you may have. If you agree with the update, please do the needful. Thank you.