### PR TITLE
feat(face-detection): allowSyntheticDefaultImports for typescript

### DIFF
--- a/face-detection/rollup.config.js
+++ b/face-detection/rollup.config.js
@@ -40,6 +40,7 @@ function config({plugins = [], output = {}, tsCompilerOptions = {}}) {
   const defaultTsOptions = {
     include: ['src/**/*.ts'],
     module: 'ES2015',
+    allowSyntheticDefaultImports: true
   };
   const tsoptions = Object.assign({}, defaultTsOptions, tsCompilerOptions);
 

--- a/face-detection/src/mediapipe/detector.ts
+++ b/face-detection/src/mediapipe/detector.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  * =============================================================================
  */
-import * as faceDetection from '@mediapipe/face_detection';
+import faceDetection from '@mediapipe/face_detection';
 import * as tf from '@tensorflow/tfjs-core';
 
 import {MEDIAPIPE_FACE_DETECTOR_KEYPOINTS} from '../constants';

--- a/face-detection/tsconfig.json
+++ b/face-detection/tsconfig.json
@@ -7,6 +7,7 @@
     "node_modules/"
   ],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/face-detection/tsconfig.test.json
+++ b/face-detection/tsconfig.test.json
@@ -7,6 +7,7 @@
     "node_modules/"
   ],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "allowSyntheticDefaultImports": true
   }
 }


### PR DESCRIPTION
When using face_detection, the final rollup output generates an esm build with imports `@mediapipe/face_detection` the following way:

```js
import{FaceDetection as e}from"@mediapipe/face_detection"
```

this breaks when using it with NEXT.js and Typescript 5.

with the following message:
```
The export FaceDetection was not found in module [project]/node_modules/@mediapipe/face_detection/face_detection.js [ssr] (ecmascript).
The module has no exports at all.
```

the suggested change adjusts the generated import statement (and usage of `FaceDetection` class)

```js
import e from"@mediapipe/face_detection"
```